### PR TITLE
Add DIC/config support

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+coverage_clover: build/logs/clover.xml
+json_path: build/logs/coveralls-upload.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+vendor
+composer.lock
+phpunit.xml
+/.settings
+/.project
+/.buildpath
+/vendor
+/build
+.idea
+nbproject
+composer.lock
+doc/html

--- a/.php_cs
+++ b/.php_cs
@@ -1,7 +1,9 @@
 <?php
 $finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->exclude('DependencyInjection/Fixture/config')
+    ->exclude('Resources/config')
     ->in('src')
-    ->in('test')
+    ->in('test');
 $config = Symfony\CS\Config\Config::create();
 $config->level(null);
 $config->fixers(

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,38 @@
+<?php
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in('src')
+    ->in('test')
+$config = Symfony\CS\Config\Config::create();
+$config->level(null);
+$config->fixers(
+    array(
+        'braces',
+        'duplicate_semicolon',
+        'elseif',
+        'empty_return',
+        'encoding',
+        'eof_ending',
+        'function_call_space',
+        'function_declaration',
+        'indentation',
+        'join_function',
+        'line_after_namespace',
+        'linefeed',
+        'lowercase_keywords',
+        'parenthesis',
+        'multiple_use',
+        'method_argument_space',
+        'object_operator',
+        'php_closing_tag',
+        'remove_lines_between_uses',
+        'short_array_syntax',
+        'short_tag',
+        'standardize_not_equal',
+        'trailing_spaces',
+        'unused_use',
+        'visibility',
+        'whitespacy_lines',
+    )
+);
+$config->finder($finder);
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+sudo: false
+
+language: php
+
+branches:
+  except:
+    - /^release-.*$/
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7
+      env:
+        - EXECUTE_CS_CHECK=true
+        - EXECUTE_TEST_COVERALLS=true
+
+before_install:
+  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - composer self-update
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --no-update satooshi/php-coveralls:dev-master ; fi
+
+install:
+  - travis_retry composer install --no-interaction --prefer-source
+  - composer info -i
+
+script:
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then php ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit ; fi
+  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run ; fi
+
+after_script:
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/coveralls ; fi
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml ; fi
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/61c75218816eebde4486
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file, in reverse chronological order by release.
+
+## TBA
+
+### Added
+
+* Nothing
+
+### Deprecated
+
+* Nothing
+
+### Removed
+
+* Nothing
+
+### Fixed
+
+* Nothing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+Visit [github.com/prooph/service-bus-symfony-bundle/](https://github.com/prooph/service-bus-symfony-bundle/ "Project Website") for the project website.
+
+- Make sure you have execute `composer install`
+- Be sure you are in the root directory
+
+## Resources
+
+If you wish to contribute to `service-bus-symfony-bundle`, please be sure to read to the following resources:
+
+ -  Coding Standards: [PSR-0/1/2/4](https://github.com/php-fig/fig-standards/tree/master/accepted)
+ -  Git Guide: [README-GIT.md](https://github.com/prooph/service-bus-symfony-bundle/blob/master/README-GIT.md)
+
+If you are working on new features, or refactoring an existing component, please create an issue first, so we can discuss
+it.
+
+## Running tests
+
+To run tests execute *phpunit*:
+
+  ```sh
+  $ ./vendor/bin/phpunit
+  ```
+
+## Running PHPCodeSniffer
+
+To check coding standards execute *phpcs*:
+
+  ```sh
+  $ ./vendor/bin/phpcs
+  ```
+
+To auto fix coding standard issues execute:
+
+  ```sh
+  $ ./vendor/bin/phpcbf
+  ```
+
+## Generate documentation
+
+To generate the documentation execute *bookdown*:
+
+```sh
+$ ./vendor/bin/bookdown doc/bookdown.json
+```
+
+## Composer shortcuts
+
+For every program above there are shortcuts defined in the `composer.json` file.
+
+* `check`: Executes PHPCodeSniffer and PHPUnit
+* `cs`: Executes PHPCodeSniffer
+* `cs-fix`: Executes PHPCodeSniffer and auto fixes issues
+* `test`: Executes PHPUnit
+* `test-coverage`: Executes PHPUnit with code coverage
+* `docs`: Generates awesome Bookdown.io docs

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+New BSD License
+===============
+
+Copyright (c) 2016, prooph software GmbH
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the names of the copyright holders nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 New BSD License
 ===============
 
-Copyright (c) 2016, prooph software GmbH
+Copyright (c) 2016, prooph software GmbH and Sascha-Oliver Prolic <saschaprolic@googlemail.com>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README-GIT.md
+++ b/README-GIT.md
@@ -1,0 +1,115 @@
+# Using GIT
+
+## Setup your own public GitHub repository
+
+Your first step is to establish a public repository from which you can pull your work into the master repository.
+
+ 1. Setup a [GitHub account](https://github.com/), if you haven't yet
+ 2. Fork the [service-bus-symfony-bundle repository](https://github.com/prooph/service-bus-symfony-bundle)
+ 3. Clone your fork locally and enter it (use your own GitHub username in the statement below)
+
+    ```sh
+    $ git clone git@github.com:[your username]/service-bus-symfony-bundle.git
+    $ cd service-bus-symfony-bundle
+    ```
+
+ 4. Add a remote to the canonical `service-bus-symfony-bundle` repository, so you can keep your fork up-to-date:
+
+    ```sh
+    $ git remote add upstream https://github.com/prooph/service-bus-symfony-bundle.git
+    $ git fetch upstream
+    ```
+
+## Keeping Up-to-Date
+
+Periodically, you should update your fork to match the canonical `service-bus-symfony-bundle` repository. we have
+added a remote to the `service-bus-symfony-bundle` repository, which allows you to do the following:
+
+```sh
+$ git checkout master
+$ git pull upstream master
+- OPTIONALLY, to keep your remote up-to-date -
+$ git push origin
+```
+
+If you're tracking other branches -- for example, the *develop* branch, where new feature development occurs --
+you'll want to do the same operations for that branch; simply substitute  "develop" for "master".
+
+## Working on service-bus-symfony-bundle
+
+When working on `service-bus-symfony-bundle`, we recommend you do each new feature or bugfix in a new branch. This simplifies the
+task of code review as well as of merging your changes into the canonical repository.
+
+A typical work flow will then consist of the following:
+
+ 1. Create a new local branch based off your master branch.
+ 2. Switch to your new local branch. (This step can be combined with the previous step with the use of `git checkout -b`.)
+ 3. Do some work, commit, repeat as necessary.
+ 4. Push the local branch to your remote repository.
+ 5. Send a pull request.
+
+The mechanics of this process are actually quite trivial. Below, we will create a branch for fixing an issue in the tracker.
+
+```sh
+$ git checkout -b 3452
+Switched to a new branch '3452'
+```
+... do some work ...
+
+```sh
+$ git commit
+```
+... write your log message ...
+
+```sh
+$ git push origin HEAD:3452
+Counting objects: 38, done.
+Delta compression using up to 2 threads.
+Compression objects: 100$ (18/18), done.
+Writing objects: 100$ (20/20), 8.19KiB, done.
+Total 20 (delta 12), reused 0 (delta 0)
+To ssh://git@github.com/prooph/service-bus-symfony-bundle.git
+   g5342..9k3532  HEAD -> master
+```
+
+You can do the pull request from GitHub. Navigate to your repository, select the branch you just created, and then
+select the "Pull Request" button in the upper right. Select the user *prooph* as the recipient.
+
+### Branch to issue the pull request
+
+Which branch should you issue a pull request against?
+
+- For fixes against the stable release, issue the pull request against the *master* branch.
+- For new features, or fixes that introduce new elements to the public API
+  (such as new public methods or properties), issue the pull request against the *develop* branch.
+
+## Branch Cleanup
+
+As you might imagine, if you are a frequent contributor, you'll start to get a ton of branches both locally and on
+your remote.
+
+Once you know that your changes have been accepted to the master repository, we suggest doing some cleanup of these
+branches.
+
+ -  Local branch cleanup
+
+    ```sh
+    $ git branch -d <branchname>
+    ```
+
+ -  Remote branch removal
+
+    ```sh
+    $ git push origin :<branchname>
+    ```
+
+
+## Feed and emails
+
+RSS feeds may be found at:
+
+`https://github.com/prooph/service-bus-symfony-bundle/commits/<branch>.atom`
+
+where &lt;branch&gt; is a branch in the repository.
+
+To subscribe to git email notifications, simply watch or fork the `service-bus-symfony-bundle` repository on GitHub.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Installation of this module uses composer. For composer documentation, please refer to
+Installation of this Symfony bundle uses Composer. For Composer documentation, please refer to
 [getcomposer.org](http://getcomposer.org/).
 
 Run `composer require prooph/service-bus-symfony-bundle` to install prooph service-bus-symfony-bundle.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# ProophServiceBus (PSB) Symfony bundle
+
+## Installation
+
+Installation of this module uses composer. For composer documentation, please refer to
+[getcomposer.org](http://getcomposer.org/).
+
+Run `composer require prooph/service-bus-symfony-bundle` to install prooph service-bus-symfony-bundle.
+
+> See [Symfony Proophessor-Do demo application](https://github.com/prooph/proophessor-do-symfony) for an example.
+
+## Documentation
+For the latest online documentation visit [http://getprooph.org/](http://getprooph.org/ "Latest documentation").
+
+Documentation is [in the doc tree](doc/), and can be compiled using [bookdown](http://bookdown.io)
+
+```console
+$ ./vendor/bin/bookdown doc/bookdown.json
+$ php -S 0.0.0.0:8080 -t doc/html/
+```
+
+Then browse to [http://localhost:8080/](http://localhost:8080/)
+
+## Support
+
+- Ask questions on [prooph-users](https://groups.google.com/forum/?hl=de#!forum/prooph) mailing list.
+- File issues at [https://github.com/prooph/service-bus-symfony-bundle/issues](https://github.com/prooph/service-bus-symfony-bundle/issues).
+- Say hello in the [prooph gitter](https://gitter.im/prooph/improoph) chat.
+
+## Contribute
+
+Please feel free to fork and extend existing or add new plugins and send a pull request with your changes!
+To establish a consistent code quality, please provide unit tests for all your changes and may adapt the documentation.
+
+## License
+
+Released under the [New BSD License](LICENSE.md).

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+*

--- a/build/logs/.gitignore
+++ b/build/logs/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+*

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,83 @@
+{
+  "name": "prooph/service-bus-symfony-bundle",
+  "description": "",
+  "homepage": "https://github.com/prooph/service-bus-symfony-bundle",
+  "license": "BSD-3-Clause",
+  "type": "service-bus-symfony-bundle",
+  "keywords": [
+    "php"
+  ],
+  "authors": [
+    {
+      "name": "Alexander Miertsch",
+      "email": "contact@prooph.de",
+      "homepage": "http://www.prooph.de",
+      "role": "maintainer"
+    },
+    {
+      "name": "Sandro Keil",
+      "homepage": "https://sandro-keil.de",
+      "role": "maintainer"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/prooph/service-bus-symfony-bundle/issues",
+    "source": "https://github.com/prooph/service-bus-symfony-bundle",
+    "docs": "http://getprooph.org/"
+  },
+  "autoload": {
+    "psr-4": {
+      "Prooph\\Bundle\\ServiceBus\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "ProophTest\\Bundle\\ServiceBus\\": "test"
+    }
+  },
+  "require": {
+    "php": "^7.0",
+    "symfony/config": "~2.8 || ~3.0",
+    "symfony/dependency-injection": "~2.8 || ~3.0",
+    "symfony/http-kernel": "~2.8 || ~3.0",
+    "prooph/service-bus": "^5.1"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^5.3",
+    "phpunit/php-invoker": "^1.1.4",
+    "fabpot/php-cs-fixer": "^1.11",
+    "bookdown/bookdown": "1.x-dev as 1.0.0",
+    "tobiju/bookdown-bootswatch-templates": "1.0.x-dev"
+  },
+  "suggest": {
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.0-dev",
+      "dev-develop": "1.1-dev"
+    }
+  },
+  "scripts": {
+    "check": [
+      "@cs",
+      "@test"
+    ],
+    "cs": "php-cs-fixer fix -v --diff --dry-run",
+    "cs-fix": "php-cs-fixer fix -v --diff",
+    "test": "phpunit --no-coverage",
+    "test-coverage": "phpunit",
+    "docs": "bookdown doc/bookdown.json"
+  },
+  "archive": {
+    "exclude": [
+      ".coveralls.yml",
+      ".travis.yml",
+      "benchmark",
+      "build",
+      "phpunit.xml*",
+      "test"
+    ]
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "",
   "homepage": "https://github.com/prooph/service-bus-symfony-bundle",
   "license": "BSD-3-Clause",
-  "type": "service-bus-symfony-bundle",
+  "type": "symfony-bundle",
   "keywords": [
     "prooph",
     "Messaging",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,17 @@
   "license": "BSD-3-Clause",
   "type": "service-bus-symfony-bundle",
   "keywords": [
-    "php"
+    "prooph",
+    "Messaging",
+    "CQRS",
+    "Symfony",
+    "Bundle",
+    "Service Bus",
+    "Event Bus",
+    "Query Bus",
+    "Message Bus",
+    "DDD",
+    "PHP"
   ],
   "authors": [
     {
@@ -13,6 +23,10 @@
       "email": "contact@prooph.de",
       "homepage": "http://www.prooph.de",
       "role": "maintainer"
+    },
+    {
+      "name": "Sascha-Oliver Prolic",
+      "email": "saschaprolic@googlemail.com"
     },
     {
       "name": "Sandro Keil",

--- a/doc/bookdown.json
+++ b/doc/bookdown.json
@@ -1,0 +1,12 @@
+{
+  "title": "prooph service-bus Symfony bundle",
+  "content": [
+    {"getting-started": "book/getting-started/bookdown.json"},
+    {"reference": "book/reference/bookdown.json"},
+    {"contribute": "book/contribute/bookdown.json"}
+  ],
+  "target": "./html",
+  "tocDepth": 2,
+  "template": "../vendor/tobiju/bookdown-bootswatch-templates/templates/main.php",
+  "copyright": "Copyright (c) 2016 <a href=\"http://getprooph.org/\" title=\"prooph software GmbH\">prooph software GmbH</a> <br/> Powered by <a href=\"https://github.com/tobiju/bookdown-bootswatch-templates\" title=\"Visit project to generate your own docs\">Bookdown Bootswatch Templates</a>"
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- disable strict to debug tests -->
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         forceCoversAnnotation="true"
+         syntaxCheck="true"
+         backupGlobals="true"
+         backupStaticAttributes="false">
+
+    <testsuites>
+        <testsuite name="Prooph Service Bus Bundle Test Suite">
+            <directory>./test</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types = 1);
+
+namespace Prooph\Bundle\ServiceBus\DependencyInjection;
+
+use Prooph\Common\Messaging\MessageFactory;
+use Prooph\ServiceBus\Plugin\Router\CommandRouter;
+use Prooph\ServiceBus\Plugin\Router\EventRouter;
+use Prooph\ServiceBus\Plugin\Router\QueryRouter;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+final class Configuration implements ConfigurationInterface
+{
+    private $debug;
+
+    private $buses = ['command_bus', 'event_bus', 'query_bus'];
+
+    /**
+     * Constructor
+     *
+     * @param Boolean $debug Whether to use the debug mode
+     */
+    public function __construct($debug)
+    {
+        $this->debug = (Boolean)$debug;
+    }
+
+    /**
+     * Normalizes XML config and defines config tree
+     *
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('prooph_service_bus');
+
+        // cycle through bus types and add XML normalization
+        foreach ($this->buses as $bus) {
+            $rootNode
+                ->beforeNormalization()
+                ->ifTrue
+                (
+                // check for XML config
+                    function ($v) use ($bus) {
+                        return !isset($v[$bus . 'es']) && isset($v[$bus]) && is_array($v[$bus]);
+                    }
+                )
+                ->then(function ($v) use ($bus) {
+                    // normalize XML config
+                    $command_bus = [];
+                    foreach ($v[$bus] as $key => $value) {
+                        $command_bus[$key] = $v[$bus][$key];
+                    }
+                    unset($v[$bus]);
+                    $v[$bus . 'es'] = $command_bus;
+
+                    return $v;
+                });
+        }
+
+        $this->addServiceBusSections($rootNode);
+
+        return $treeBuilder;
+    }
+
+    /**
+     * Add service bus section to configuration tree
+     *
+     * @link https://github.com/prooph/service-bus
+     *
+     * @param ArrayNodeDefinition $node
+     */
+    private function addServiceBusSections(ArrayNodeDefinition $node)
+    {
+        $node
+            ->fixXmlConfig('command_bus')
+            ->children()
+                ->append($this->getServiceBusNode('command', CommandRouter::class))
+            ->end()
+            ->fixXmlConfig('event_bus')
+            ->children()
+                ->append($this->getServiceBusNode('event', EventRouter::class))
+            ->end()
+            ->fixXmlConfig('query_bus')
+            ->children()
+                ->append($this->getServiceBusNode('query', QueryRouter::class))
+            ->end();
+    }
+
+    /**
+     * Return the service bus node
+     *
+     * @return ArrayNodeDefinition
+     */
+    private function getServiceBusNode($type, $routerClass)
+    {
+        $treeBuilder = new TreeBuilder();
+        $node = $treeBuilder->root($type . '_buses');
+
+        /** @var $commandBusNode ArrayNodeDefinition */
+        $commandBusNode = $node
+            ->requiresAtLeastOneElement()
+            ->useAttributeAsKey('name')
+            ->prototype('array')
+        ;
+
+        $commandBusNode
+            ->fixXmlConfig('plugin', 'plugins')
+            ->children()
+                ->scalarNode('message_factory')->defaultValue(MessageFactory::class)->end()
+                ->arrayNode('plugins')
+                    ->prototype('scalar')->end()
+                ->end()
+                ->arrayNode('router')
+                    ->fixXmlConfig('route', 'routes')
+                    ->children()
+                        ->scalarNode('type')->defaultValue($routerClass)->end()
+                        ->arrayNode('routes')
+                            ->useAttributeAsKey($type)
+                            // TODO handle event bus list
+                            ->prototype('scalar')
+                            ->beforeNormalization()
+                                ->ifString()
+                                ->then(function ($v) {
+                                    return $v;
+                                })
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $node;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -43,9 +43,9 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('prooph_service_bus');
 
-        $this->addServiceBusSections('command',  CommandRouter::class, $rootNode);
-        $this->addServiceBusSections('event',  EventRouter::class, $rootNode);
-        $this->addServiceBusSections('query',  QueryRouter::class, $rootNode);
+        $this->addServiceBusSection('command',  CommandRouter::class, $rootNode);
+        $this->addServiceBusSection('event',  EventRouter::class, $rootNode);
+        $this->addServiceBusSection('query',  QueryRouter::class, $rootNode);
 
         return $treeBuilder;
     }
@@ -55,9 +55,11 @@ final class Configuration implements ConfigurationInterface
      *
      * @link https://github.com/prooph/service-bus
      *
+     * @param string $type Bus type
+     * @param string $routerClass Bus router class
      * @param ArrayNodeDefinition $node
      */
-    private function addServiceBusSections(string $type, string $routerClass, ArrayNodeDefinition $node)
+    private function addServiceBusSection(string $type, string $routerClass, ArrayNodeDefinition $node)
     {
         $treeBuilder = new TreeBuilder();
         $routesNode = $treeBuilder->root('routes');

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -120,6 +120,10 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('message_factory')->defaultValue(MessageFactory::class)->end()
                 ->arrayNode('plugins')
+                    ->beforeNormalization()
+                        // fix single node in XML
+                        ->ifString()->then(function ($v) { return [$v];})
+                    ->end()
                     ->prototype('scalar')->end()
                 ->end()
                 ->arrayNode('router')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ final class Configuration implements ConfigurationInterface
 {
     private $debug;
 
-    private $buses = ['command_bus', 'event_bus', 'query_bus'];
+    private $availableBuses = ['command_bus', 'event_bus', 'query_bus'];
 
     /**
      * Constructor
@@ -46,12 +46,12 @@ final class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('prooph_service_bus');
 
         // cycle through bus types and add XML normalization
-        foreach ($this->buses as $bus) {
+        foreach ($this->availableBuses as $bus) {
             $rootNode
                 ->beforeNormalization()
                 ->ifTrue
                 (
-                // check for XML config
+                    // check for XML config
                     function ($v) use ($bus) {
                         return !isset($v[$bus . 'es']) && isset($v[$bus]) && is_array($v[$bus]);
                     }

--- a/src/DependencyInjection/ProophServiceBusExtension.php
+++ b/src/DependencyInjection/ProophServiceBusExtension.php
@@ -11,10 +11,10 @@ declare (strict_types = 1);
 
 namespace Prooph\Bundle\ServiceBus\DependencyInjection;
 
+use Prooph\Bundle\ServiceBus\Exception\RuntimeException;
 use Prooph\ServiceBus\CommandBus;
 use Prooph\ServiceBus\EventBus;
 use Prooph\ServiceBus\QueryBus;
-use Prooph\ServiceBus\Exception\RuntimeException;
 use Prooph\ServiceBus\Plugin\Router\CommandRouter;
 use Prooph\ServiceBus\Plugin\Router\EventRouter;
 use Prooph\ServiceBus\Plugin\Router\QueryRouter;
@@ -116,7 +116,7 @@ final class ProophServiceBusExtension extends Extension
      * @param ContainerBuilder $container
      * @throws \Symfony\Component\DependencyInjection\Exception\BadMethodCallException
      * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @throws \Prooph\ServiceBus\Exception\RuntimeException
+     * @throws \Prooph\Bundle\ServiceBus\Exception\RuntimeException
      */
     private function loadBus(string $type, string $name, array $options, ContainerBuilder $container)
     {

--- a/src/DependencyInjection/ProophServiceBusExtension.php
+++ b/src/DependencyInjection/ProophServiceBusExtension.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types = 1);
+
+namespace Prooph\Bundle\ServiceBus\DependencyInjection;
+
+use Prooph\ServiceBus\{
+    CommandBus,
+    EventBus,
+    QueryBus,
+    Exception\RuntimeException,
+    Plugin\MessageFactoryPlugin,
+    Plugin\Router\CommandRouter,
+    Plugin\Router\EventRouter,
+    Plugin\Router\QueryRouter
+};
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * Defines and load message bus instances.
+ */
+final class ProophServiceBusExtension extends Extension
+{
+    private $buses = [
+        'command_bus' => CommandBus::class,
+        'event_bus' => EventBus::class,
+        'query_bus' => QueryBus::class,
+    ];
+
+    public function getNamespace()
+    {
+        return 'http://getprooph.org/schemas/symfony-dic/prooph';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return new Configuration($container->getParameter('kernel.debug'));
+    }
+
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = $this->getConfiguration($configs, $container);
+        $config = $this->processConfiguration($configuration, $configs);
+
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('service_bus.xml');
+
+        foreach ($this->buses as $bus => $class) {
+            if (!empty($config[$bus . 'es'])) {
+                $this->busLoad($bus, $class, $config, $container, $loader);
+            }
+        }
+
+        $this->addClassesToCompile([
+            CommandBus::class,
+            QueryBus::class,
+            EventBus::class,
+            CommandRouter::class,
+            EventRouter::class,
+            QueryRouter::class,
+        ]);
+    }
+
+    /**
+     * Loads bus configuration depending on type. For configuration examples, please take look at
+     * test/DependencyInjection/Fixture/config files
+     *
+     * @param string $type
+     * @param string $class
+     * @param array $config
+     * @param ContainerBuilder $container
+     * @param XmlFileLoader $loader
+     */
+    private function busLoad(
+        string $type,
+        string $class,
+        array $config,
+        ContainerBuilder $container,
+        XmlFileLoader $loader
+    ) {
+        $loader->load($type . '.xml');
+
+        $typePlural = $type . 'es';
+        $commandBuses = [];
+
+        foreach (array_keys($config[$typePlural]) as $name) {
+            $commandBuses[$name] = sprintf('prooph_service_bus.' . $type . '.%s_bus', $name);
+        }
+        $container->setParameter('prooph_service_bus.' . $typePlural, $commandBuses);
+
+        $def = $container->getDefinition('prooph_service_bus.' . $type);
+        $def->setClass($class);
+
+        foreach ($config[$typePlural] as $name => $options) {
+            $this->loadBus($type, $name, $options, $container);
+        }
+    }
+
+    /**
+     * Initializes service bus class with plugins and routes
+     *
+     * @param string $type
+     * @param string $name
+     * @param array $options
+     * @param ContainerBuilder $container
+     */
+    private function loadBus(string $type, string $name, array $options, ContainerBuilder $container)
+    {
+        $commandBusDefinition = $container->setDefinition(
+            sprintf('prooph_service_bus.%s.%s_bus', $type, $name),
+            new DefinitionDecorator('prooph_service_bus.' . $type)
+        );
+
+        if (!empty($options['plugins'])) {
+            foreach ($options['plugins'] as $index => $util) {
+                if (!is_string($util) || !$container->has($util)) {
+                    throw new RuntimeException(sprintf(
+                        'Wrong message bus utility "%s" configured. It is unknown by the container.',
+                        $util
+                    ));
+                }
+
+                $commandBusDefinition->addMethodCall('utilize', [$container->get($util)]);
+            }
+        }
+
+        $commandBusDefinition->addMethodCall(
+            'utilize',
+            [new MessageFactoryPlugin($container->get($options['message_factory']))]
+        );
+
+        if (!empty($options['router']['routes'])) {
+            $commandBusDefinition->addMethodCall('utilize', [$this->attachRouter($options['router'])]);
+        }
+    }
+
+    private function attachRouter(array $routerConfig)
+    {
+        $routerClass = (string)$routerConfig['type'];
+
+        return new $routerClass($routerConfig['routes'] ?? []);
+    }
+
+}

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types = 1);
+
+namespace Prooph\Bundle\ServiceBus\Exception;
+
+class RuntimeException extends \RuntimeException implements ServiceBusException
+{
+}

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -7,7 +7,7 @@
  * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
  */
 
-declare(strict_types = 1);
+declare (strict_types = 1);
 
 namespace Prooph\Bundle\ServiceBus\Exception;
 

--- a/src/Exception/ServiceBusException.php
+++ b/src/Exception/ServiceBusException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types = 1);
+
+namespace Prooph\Bundle\ServiceBus\Exception;
+
+/**
+ * Exception interface for component
+ */
+interface ServiceBusException
+{
+}

--- a/src/Exception/ServiceBusException.php
+++ b/src/Exception/ServiceBusException.php
@@ -7,7 +7,7 @@
  * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
  */
 
-declare(strict_types = 1);
+declare (strict_types = 1);
 
 namespace Prooph\Bundle\ServiceBus\Exception;
 

--- a/src/ProophServiceBusBundle.php
+++ b/src/ProophServiceBusBundle.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Prooph\Bundle\ServiceBus;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+final class ProophServiceBusBundle extends Bundle
+{
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        // TODO RegisterEventListenersAndSubscribersPass like doctrine ?
+    }
+}

--- a/src/ProophServiceBusBundle.php
+++ b/src/ProophServiceBusBundle.php
@@ -7,6 +7,8 @@
  * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
  */
 
+declare (strict_types = 1);
+
 namespace Prooph\Bundle\ServiceBus;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Resources/config/command_bus.xml
+++ b/src/Resources/config/command_bus.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="prooph_service_bus.command_bus" class="Prooph\ServiceBus\CommandBus" abstract="true" />
+    </services>
+</container>

--- a/src/Resources/config/command_bus.xml
+++ b/src/Resources/config/command_bus.xml
@@ -4,7 +4,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="prooph_service_bus.command_bus_router.class">Prooph\ServiceBus\Plugin\Router\CommandRouter</parameter>
+    </parameters>
+
     <services>
         <service id="prooph_service_bus.command_bus" class="Prooph\ServiceBus\CommandBus" abstract="true" />
+        <service id="prooph_service_bus.command_bus_router" class="%prooph_service_bus.command_bus_router.class%" public="false" abstract="true" />
     </services>
 </container>

--- a/src/Resources/config/event_bus.xml
+++ b/src/Resources/config/event_bus.xml
@@ -4,7 +4,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="prooph_service_bus.event_bus_router.class">Prooph\ServiceBus\Plugin\Router\EventRouter</parameter>
+    </parameters>
+
     <services>
         <service id="prooph_service_bus.event_bus" class="Prooph\ServiceBus\EventBus" abstract="true" />
+        <service id="prooph_service_bus.event_bus_router" class="%prooph_service_bus.event_bus_router.class%" public="false" abstract="true" />
     </services>
 </container>

--- a/src/Resources/config/event_bus.xml
+++ b/src/Resources/config/event_bus.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="prooph_service_bus.event_bus" class="Prooph\ServiceBus\EventBus" abstract="true" />
+    </services>
+</container>

--- a/src/Resources/config/query_bus.xml
+++ b/src/Resources/config/query_bus.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="prooph_service_bus.query_bus" class="Prooph\ServiceBus\QueryBus" abstract="true" />
+    </services>
+</container>

--- a/src/Resources/config/query_bus.xml
+++ b/src/Resources/config/query_bus.xml
@@ -4,7 +4,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="prooph_service_bus.query_bus_router.class">Prooph\ServiceBus\Plugin\Router\QueryRouter</parameter>
+    </parameters>
+
     <services>
         <service id="prooph_service_bus.query_bus" class="Prooph\ServiceBus\QueryBus" abstract="true" />
+        <service id="prooph_service_bus.query_bus_router" class="%prooph_service_bus.query_bus_router.class%" public="false" abstract="true" />
     </services>
 </container>

--- a/src/Resources/config/service_bus.xml
+++ b/src/Resources/config/service_bus.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy" class="Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy" />
+
+        <!-- we use interfaces as id here, to define default classes -->
+        <service id="Prooph\Common\Messaging\MessageFactory" class="Prooph\Common\Messaging\FQCNMessageFactory" />
+    </services>
+</container>

--- a/src/Resources/config/service_bus.xml
+++ b/src/Resources/config/service_bus.xml
@@ -4,8 +4,13 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="prooph_service_bus.message_factory_plugin.class">Prooph\ServiceBus\Plugin\MessageFactoryPlugin</parameter>
+    </parameters>
+
     <services>
         <service id="Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy" class="Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy" />
+        <service id="prooph_service_bus.message_factory_plugin" class="%prooph_service_bus.message_factory_plugin.class%" public="false" abstract="true" />
 
         <!-- we use interfaces as id here, to define default classes -->
         <service id="Prooph\Common\Messaging\MessageFactory" class="Prooph\Common\Messaging\FQCNMessageFactory" />

--- a/test/BundleTest.php
+++ b/test/BundleTest.php
@@ -9,7 +9,7 @@
 
 declare (strict_types = 1);
 
-namespace ProophTest\Bundle;
+namespace ProophTest\Bundle\ServiceBus;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Prooph\Bundle\ServiceBus\ProophServiceBusBundle;

--- a/test/BundleTest.php
+++ b/test/BundleTest.php
@@ -7,7 +7,7 @@
  * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
  */
 
-declare(strict_types = 1);
+declare (strict_types = 1);
 
 namespace ProophTest\Bundle;
 

--- a/test/BundleTest.php
+++ b/test/BundleTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types = 1);
+
+namespace ProophTest\Bundle;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Prooph\Bundle\ServiceBus\ProophServiceBusBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class BundleTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_builds_compiler_pass()
+    {
+        $container = new ContainerBuilder();
+        $bundle = new ProophServiceBusBundle();
+        $bundle->build($container);
+
+        $config = $container->getCompilerPassConfig();
+        $passes = $config->getBeforeOptimizationPasses();
+
+        // TODO assert something
+    }
+}

--- a/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
+++ b/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
@@ -99,7 +99,7 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
             'kernel.bundles' => $map,
             'kernel.cache_dir' => sys_get_temp_dir(),
             'kernel.environment' => 'test',
-            'kernel.root_dir' => __DIR__ . '/../../src', // src dir
+            'kernel.root_dir' => __DIR__ . '/../../src',
         ]));
     }
 

--- a/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
+++ b/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
@@ -26,12 +26,31 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
 
         $config = $container->getDefinition('prooph_service_bus.command_bus.main_bus');
 
-        self::assertEquals('Prooph\ServiceBus\CommandBus', $config->getClass());
+        self::assertEquals(CommandBus::class, $config->getClass());
 
         /* @var $commandBus CommandBus */
         $commandBus = $container->get('prooph_service_bus.command_bus.main_bus');
 
         self::assertInstanceOf(CommandBus::class, $commandBus);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_multiple_command_buses()
+    {
+        $container = $this->loadContainer('command_bus_multiple');
+
+        foreach (['main', 'second'] as $name) {
+            $config = $container->getDefinition('prooph_service_bus.command_bus.' . $name . '_bus');
+
+            self::assertEquals(CommandBus::class, $config->getClass());
+
+            /* @var $commandBus CommandBus */
+            $commandBus = $container->get('prooph_service_bus.command_bus.' . $name . '_bus');
+
+            self::assertInstanceOf(CommandBus::class, $commandBus);
+        }
     }
 
     /**
@@ -43,12 +62,31 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
 
         $config = $container->getDefinition('prooph_service_bus.query_bus.main_bus');
 
-        self::assertEquals('Prooph\ServiceBus\QueryBus', $config->getClass());
+        self::assertEquals(QueryBus::class, $config->getClass());
 
         /* @var $queryBus QueryBus */
         $queryBus = $container->get('prooph_service_bus.query_bus.main_bus');
 
         self::assertInstanceOf(QueryBus::class, $queryBus);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_multiple_query_buses()
+    {
+        $container = $this->loadContainer('query_bus_multiple');
+
+        foreach (['main', 'second'] as $name) {
+            $config = $container->getDefinition('prooph_service_bus.query_bus.' . $name . '_bus');
+
+            self::assertEquals(QueryBus::class, $config->getClass());
+
+            /* @var $queryBus QueryBus */
+            $queryBus = $container->get('prooph_service_bus.query_bus.' . $name . '_bus');
+
+            self::assertInstanceOf(QueryBus::class, $queryBus);
+        }
     }
 
     /**
@@ -60,12 +98,32 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
 
         $config = $container->getDefinition('prooph_service_bus.event_bus.main_bus');
 
-        self::assertEquals('Prooph\ServiceBus\EventBus', $config->getClass());
+        self::assertEquals(EventBus::class, $config->getClass());
 
         /* @var $eventBus EventBus */
         $eventBus = $container->get('prooph_service_bus.event_bus.main_bus');
 
         self::assertInstanceOf(EventBus::class, $eventBus);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_multiple_event_buses()
+    {
+        $container = $this->loadContainer('event_bus_multiple');
+
+
+        foreach (['main', 'second'] as $name) {
+            $config = $container->getDefinition('prooph_service_bus.event_bus.' . $name . '_bus');
+
+            self::assertEquals(EventBus::class, $config->getClass());
+
+            /* @var $eventBus EventBus */
+            $eventBus = $container->get('prooph_service_bus.event_bus.' . $name . '_bus');
+
+            self::assertInstanceOf(EventBus::class, $eventBus);
+        }
     }
 
     private function loadContainer($fixture, CompilerPassInterface $compilerPass = null)

--- a/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
+++ b/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
@@ -1,5 +1,13 @@
 <?php
-declare(strict_types = 1);
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+declare (strict_types = 1);
 
 namespace ProophTest\Bundle\ServiceBus\DependencyInjection;
 

--- a/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
+++ b/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
@@ -19,6 +19,9 @@ use Prooph\ServiceBus\QueryBus;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Dumper\Dumper;
+use Symfony\Component\DependencyInjection\Dumper\XmlDumper;
+use Symfony\Component\DependencyInjection\Dumper\YamlDumper;
 use \Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 abstract class AbtractServiceBusExtensionTestCase extends TestCase
@@ -64,6 +67,14 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
     /**
      * @test
      */
+    public function it_dumps_multiple_command_buses()
+    {
+        $this->dump('command_bus_multiple');
+    }
+
+    /**
+     * @test
+     */
     public function it_creates_a_query_bus()
     {
         $container = $this->loadContainer('query_bus');
@@ -95,6 +106,14 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
 
             self::assertInstanceOf(QueryBus::class, $queryBus);
         }
+    }
+
+    /**
+     * @test
+     */
+    public function it_dumps_multiple_query_buses()
+    {
+        $this->dump('query_bus_multiple');
     }
 
     /**
@@ -132,6 +151,14 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
 
             self::assertInstanceOf(EventBus::class, $eventBus);
         }
+    }
+
+    /**
+     * @test
+     */
+    public function it_dumps_multiple_event_buses()
+    {
+        $this->dump('event_bus_multiple');
     }
 
     private function loadContainer($fixture, CompilerPassInterface $compilerPass = null)
@@ -174,5 +201,19 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
         $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveDefinitionTemplatesPass()]);
         $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
+    }
+
+    private function dump(string $configFile)
+    {
+        $container = $this->loadContainer($configFile);
+        $dumper = null;
+
+        if ($this instanceof XmlServiceBusExtensionTest) {
+            $dumper = new XmlDumper($container);
+        } elseif ($this instanceof YamlServiceBusExtensionTest) {
+            $dumper = new YamlDumper($container);
+        }
+        self::assertInstanceOf(Dumper::class, $dumper, sprintf('Test type "%s" not supported', get_class($this)));
+        self::assertNotEmpty($dumper->dump());
     }
 }

--- a/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
+++ b/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types = 1);
+
+namespace ProophTest\Bundle\ServiceBus\DependencyInjection;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Prooph\Bundle\ServiceBus\DependencyInjection\ProophServiceBusExtension;
+use Prooph\ServiceBus\CommandBus;
+use Prooph\ServiceBus\EventBus;
+use Prooph\ServiceBus\QueryBus;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use \Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+abstract class AbtractServiceBusExtensionTestCase extends TestCase
+{
+    abstract protected function loadFromFile(ContainerBuilder $container, $file);
+
+    /**
+     * @test
+     */
+    public function it_creates_a_command_bus()
+    {
+        $container = $this->loadContainer('command_bus');
+
+        $config = $container->getDefinition('prooph_service_bus.command_bus.main_bus');
+
+        self::assertEquals('Prooph\ServiceBus\CommandBus', $config->getClass());
+
+        /* @var $commandBus CommandBus */
+        $commandBus = $container->get('prooph_service_bus.command_bus.main_bus');
+
+        self::assertInstanceOf(CommandBus::class, $commandBus);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_query_bus()
+    {
+        $container = $this->loadContainer('query_bus');
+
+        $config = $container->getDefinition('prooph_service_bus.query_bus.main_bus');
+
+        self::assertEquals('Prooph\ServiceBus\QueryBus', $config->getClass());
+
+        /* @var $queryBus QueryBus */
+        $queryBus = $container->get('prooph_service_bus.query_bus.main_bus');
+
+        self::assertInstanceOf(QueryBus::class, $queryBus);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_an_event_bus()
+    {
+        $container = $this->loadContainer('event_bus');
+
+        $config = $container->getDefinition('prooph_service_bus.event_bus.main_bus');
+
+        self::assertEquals('Prooph\ServiceBus\EventBus', $config->getClass());
+
+        /* @var $eventBus EventBus */
+        $eventBus = $container->get('prooph_service_bus.event_bus.main_bus');
+
+        self::assertInstanceOf(EventBus::class, $eventBus);
+    }
+
+    private function loadContainer($fixture, CompilerPassInterface $compilerPass = null)
+    {
+        $container = $this->getContainer();
+        $container->registerExtension(new ProophServiceBusExtension());
+
+        $this->loadFromFile($container, $fixture);
+
+        if (null !== $compilerPass) {
+            $container->addCompilerPass($compilerPass);
+        }
+
+        $this->compileContainer($container);
+
+        return $container;
+    }
+
+    private function getContainer(array $bundles = [])
+    {
+        $map = [];
+
+        foreach ($bundles as $bundle) {
+            require_once __DIR__ . '/Fixture/Bundles/' . $bundle . '/' . $bundle . '.php';
+
+            $map[$bundle] = 'Fixture\\Bundles\\' . $bundle . '\\' . $bundle;
+        }
+
+        return new ContainerBuilder(new ParameterBag([
+            'kernel.debug' => false,
+            'kernel.bundles' => $map,
+            'kernel.cache_dir' => sys_get_temp_dir(),
+            'kernel.environment' => 'test',
+            'kernel.root_dir' => __DIR__ . '/../../src', // src dir
+        ]));
+    }
+
+    private function compileContainer(ContainerBuilder $container)
+    {
+        $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveDefinitionTemplatesPass()]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->compile();
+    }
+}

--- a/test/DependencyInjection/Fixture/config/xml/command_bus.xml
+++ b/test/DependencyInjection/Fixture/config/xml/command_bus.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
+
+    <config>
+        <command_bus name="main" message_factory="Prooph\Common\Messaging\MessageFactory">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy2</plugin>
+            <router type="Prooph\ServiceBus\Plugin\Router\CommandRouter">
+                <route command="Prooph\ProophessorDo\Model\User\Command\RegisterUser">Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler</route>
+                <route command="Prooph\ProophessorDo\Model\User\Command\UpdateUser">Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler</route>
+            </router>
+        </command_bus>
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/xml/command_bus.xml
+++ b/test/DependencyInjection/Fixture/config/xml/command_bus.xml
@@ -9,7 +9,6 @@
     <config>
         <command_bus name="main" message_factory="Prooph\Common\Messaging\MessageFactory">
             <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
-            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy2</plugin>
             <router type="Prooph\ServiceBus\Plugin\Router\CommandRouter">
                 <route command="Prooph\ProophessorDo\Model\User\Command\RegisterUser">Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler</route>
                 <route command="Prooph\ProophessorDo\Model\User\Command\UpdateUser">Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler</route>

--- a/test/DependencyInjection/Fixture/config/xml/command_bus_multiple.xml
+++ b/test/DependencyInjection/Fixture/config/xml/command_bus_multiple.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
+
+    <config>
+        <command_bus name="main" message_factory="Prooph\Common\Messaging\MessageFactory">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <router type="Prooph\ServiceBus\Plugin\Router\CommandRouter">
+                <route command="Prooph\ProophessorDo\Model\User\Command\RegisterUser">Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler</route>
+                <route command="Prooph\ProophessorDo\Model\User\Command\UpdateUser">Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler</route>
+            </router>
+        </command_bus>
+        <!-- uses default values -->
+        <command_bus name="second">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <router>
+                <route command="Prooph\ProophessorDo\Model\User\Command\RegisterUser">Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler</route>
+                <route command="Prooph\ProophessorDo\Model\User\Command\UpdateUser">Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler</route>
+            </router>
+        </command_bus>
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/xml/event_bus.xml
+++ b/test/DependencyInjection/Fixture/config/xml/event_bus.xml
@@ -10,8 +10,8 @@
             <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
             <router type="Prooph\ServiceBus\Plugin\Router\EventRouter">
                 <route event="Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted">
-                    <value>Prooph\ProophessorDo\Projection\Todo\TodoProjector</value>
-                    <value>Prooph\ProophessorDo\Projection\Todo\UserProjector</value>
+                    <listener>Prooph\ProophessorDo\Projection\Todo\TodoProjector</listener>
+                    <listener>Prooph\ProophessorDo\Projection\Todo\UserProjector</listener>
                 </route>
             </router>
         </event_bus>

--- a/test/DependencyInjection/Fixture/config/xml/event_bus.xml
+++ b/test/DependencyInjection/Fixture/config/xml/event_bus.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
+    <config>
+        <event_bus name="main" message_factory="Prooph\Common\Messaging\MessageFactory">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <router type="Prooph\ServiceBus\Plugin\Router\EventRouter">
+                <route event="Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted">
+                    <value>Prooph\ProophessorDo\Projection\Todo\TodoProjector</value>
+                    <value>Prooph\ProophessorDo\Projection\Todo\UserProjector</value>
+                </route>
+            </router>
+        </event_bus>
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/xml/event_bus_multiple.xml
+++ b/test/DependencyInjection/Fixture/config/xml/event_bus_multiple.xml
@@ -11,7 +11,6 @@
             <router type="Prooph\ServiceBus\Plugin\Router\EventRouter">
                 <route event="Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted">
                     <listener>Prooph\ProophessorDo\Projection\Todo\TodoProjector</listener>
-                    <listener>Prooph\ProophessorDo\Projection\Todo\UserProjector</listener>
                 </route>
             </router>
         </event_bus>

--- a/test/DependencyInjection/Fixture/config/xml/event_bus_multiple.xml
+++ b/test/DependencyInjection/Fixture/config/xml/event_bus_multiple.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
+    <config>
+        <event_bus name="main" message_factory="Prooph\Common\Messaging\MessageFactory">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <router type="Prooph\ServiceBus\Plugin\Router\EventRouter">
+                <route event="Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted">
+                    <listener>Prooph\ProophessorDo\Projection\Todo\TodoProjector</listener>
+                    <listener>Prooph\ProophessorDo\Projection\Todo\UserProjector</listener>
+                </route>
+            </router>
+        </event_bus>
+        <!-- uses default values -->
+        <event_bus name="second">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <router>
+                <route event="Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted">
+                    <listener>Prooph\ProophessorDo\Projection\Todo\TodoProjector</listener>
+                    <listener>Prooph\ProophessorDo\Projection\Todo\UserProjector</listener>
+                </route>
+            </router>
+        </event_bus>
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/xml/query_bus.xml
+++ b/test/DependencyInjection/Fixture/config/xml/query_bus.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
+
+    <config>
+        <query_bus name="main" message_factory="Prooph\Common\Messaging\MessageFactory">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <router type="Prooph\ServiceBus\Plugin\Router\QueryRouter">
+                <route query="Prooph\ProophessorDo\Model\User\Query\UserList">
+                    Prooph\ProophessorDo\Model\User\Query\UserListUserHandler
+                </route>
+                <route query="Prooph\ProophessorDo\Model\Todo\Query\TodoList">
+                    Prooph\ProophessorDo\Model\User\Query\TodoListHandler
+                </route>
+            </router>
+        </query_bus>
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/xml/query_bus_multiple.xml
+++ b/test/DependencyInjection/Fixture/config/xml/query_bus_multiple.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
+
+    <config>
+        <query_bus name="main" message_factory="Prooph\Common\Messaging\MessageFactory">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <router type="Prooph\ServiceBus\Plugin\Router\QueryRouter">
+                <route query="Prooph\ProophessorDo\Model\User\Query\UserList">Prooph\ProophessorDo\Model\User\Query\UserListUserHandler</route>
+                <route query="Prooph\ProophessorDo\Model\Todo\Query\TodoList">Prooph\ProophessorDo\Model\User\Query\TodoListHandler</route>
+            </router>
+        </query_bus>
+        <!-- uses default values -->
+        <query_bus name="second">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <router>
+                <route query="Prooph\ProophessorDo\Model\User\Query\UserList">Prooph\ProophessorDo\Model\User\Query\UserListUserHandler</route>
+                <route query="Prooph\ProophessorDo\Model\Todo\Query\TodoList">Prooph\ProophessorDo\Model\User\Query\TodoListHandler</route>
+            </router>
+        </query_bus>
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/yml/command_bus.yml
+++ b/test/DependencyInjection/Fixture/config/yml/command_bus.yml
@@ -1,0 +1,11 @@
+prooph_service_bus:
+  command_buses:
+    main:
+      message_factory: 'Prooph\Common\Messaging\MessageFactory'
+      router:
+        type: 'Prooph\ServiceBus\Plugin\Router\CommandRouter'
+        routes:
+          'Prooph\ProophessorDo\Model\User\Command\RegisterUser': 'Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler'
+          'Prooph\ProophessorDo\Model\User\Command\UpdateUser': 'Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler'
+      plugins:
+        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'

--- a/test/DependencyInjection/Fixture/config/yml/command_bus_multiple.yml
+++ b/test/DependencyInjection/Fixture/config/yml/command_bus_multiple.yml
@@ -1,0 +1,21 @@
+prooph_service_bus:
+  command_buses:
+    main:
+      plugins:
+        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
+      message_factory: 'Prooph\Common\Messaging\MessageFactory'
+      router:
+        type: 'Prooph\ServiceBus\Plugin\Router\CommandRouter'
+        routes:
+          'Prooph\ProophessorDo\Model\User\Command\RegisterUser': 'Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler'
+          'Prooph\ProophessorDo\Model\User\Command\UpdateUser': 'Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler'
+
+    # uses default values
+    second:
+      plugins:
+        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
+        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
+      router:
+        routes:
+          'Prooph\ProophessorDo\Model\User\Command\RegisterUser': 'Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler'
+          'Prooph\ProophessorDo\Model\User\Command\UpdateUser': 'Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler'

--- a/test/DependencyInjection/Fixture/config/yml/event_bus.yml
+++ b/test/DependencyInjection/Fixture/config/yml/event_bus.yml
@@ -1,0 +1,10 @@
+prooph_service_bus:
+  event_buses:
+    main:
+      router:
+        routes:
+          'Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted':
+            - 'Prooph\ProophessorDo\Projection\Todo\TodoProjector'
+            - 'Prooph\ProophessorDo\Projection\User\UserProjector'
+      plugins:
+        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'

--- a/test/DependencyInjection/Fixture/config/yml/event_bus_multiple.yml
+++ b/test/DependencyInjection/Fixture/config/yml/event_bus_multiple.yml
@@ -1,8 +1,6 @@
 prooph_service_bus:
   event_buses:
     main:
-      plugins:
-        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
       message_factory: 'Prooph\Common\Messaging\MessageFactory'
       router:
         type: 'Prooph\ServiceBus\Plugin\Router\EventRouter'
@@ -10,3 +8,5 @@ prooph_service_bus:
           'Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted':
             - 'Prooph\ProophessorDo\Projection\Todo\TodoProjector'
             - 'Prooph\ProophessorDo\Projection\User\UserProjector'
+      plugins:
+        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'

--- a/test/DependencyInjection/Fixture/config/yml/event_bus_multiple.yml
+++ b/test/DependencyInjection/Fixture/config/yml/event_bus_multiple.yml
@@ -10,3 +10,12 @@ prooph_service_bus:
             - 'Prooph\ProophessorDo\Projection\User\UserProjector'
       plugins:
         - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
+
+    # uses default values
+    second:
+      plugins:
+        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
+      router:
+        routes:
+          'Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted':
+            - 'Prooph\ProophessorDo\Projection\Todo\TodoProjector'

--- a/test/DependencyInjection/Fixture/config/yml/query_bus.yml
+++ b/test/DependencyInjection/Fixture/config/yml/query_bus.yml
@@ -1,0 +1,9 @@
+prooph_service_bus:
+  query_buses:
+    main:
+      router:
+        routes:
+          'Prooph\ProophessorDo\Model\User\Query\UserList': 'Prooph\ProophessorDo\Model\User\Query\UserListUserHandler'
+          'Prooph\ProophessorDo\Model\Todo\Query\TodoList': 'Prooph\ProophessorDo\Model\User\Query\TodoListHandler'
+      plugins:
+        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'

--- a/test/DependencyInjection/Fixture/config/yml/query_bus_multiple.yml
+++ b/test/DependencyInjection/Fixture/config/yml/query_bus_multiple.yml
@@ -9,3 +9,13 @@ prooph_service_bus:
         routes:
           'Prooph\ProophessorDo\Model\User\Query\UserList': 'Prooph\ProophessorDo\Model\User\Query\UserListUserHandler'
           'Prooph\ProophessorDo\Model\Todo\Query\TodoList': 'Prooph\ProophessorDo\Model\User\Query\TodoListHandler'
+
+    # uses default values
+    second:
+      plugins:
+        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
+        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
+      router:
+        routes:
+          'Prooph\ProophessorDo\Model\User\Query\UserList': 'Prooph\ProophessorDo\Model\User\Query\UserListUserHandler'
+          'Prooph\ProophessorDo\Model\Todo\Query\TodoList': 'Prooph\ProophessorDo\Model\User\Query\TodoListHandler'

--- a/test/DependencyInjection/XmlServiceBusExtensionTest.php
+++ b/test/DependencyInjection/XmlServiceBusExtensionTest.php
@@ -1,8 +1,15 @@
 <?php
-declare(strict_types = 1);
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+declare (strict_types = 1);
 
 namespace ProophTest\Bundle\ServiceBus\DependencyInjection;
-
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/test/DependencyInjection/XmlServiceBusExtensionTest.php
+++ b/test/DependencyInjection/XmlServiceBusExtensionTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types = 1);
+
+namespace ProophTest\Bundle\ServiceBus\DependencyInjection;
+
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+
+class XmlServiceBusExtensionTest extends AbtractServiceBusExtensionTestCase
+{
+    protected function loadFromFile(ContainerBuilder $container, $file)
+    {
+        $loadYaml = new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixture/config/xml'));
+        $loadYaml->load($file.'.xml');
+    }
+}

--- a/test/DependencyInjection/XmlServiceBusExtensionTest.php
+++ b/test/DependencyInjection/XmlServiceBusExtensionTest.php
@@ -12,7 +12,7 @@ class XmlServiceBusExtensionTest extends AbtractServiceBusExtensionTestCase
 {
     protected function loadFromFile(ContainerBuilder $container, $file)
     {
-        $loadYaml = new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixture/config/xml'));
-        $loadYaml->load($file.'.xml');
+        $loadXml = new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixture/config/xml'));
+        $loadXml->load($file.'.xml');
     }
 }

--- a/test/DependencyInjection/YamlServiceBusExtensionTest.php
+++ b/test/DependencyInjection/YamlServiceBusExtensionTest.php
@@ -1,8 +1,15 @@
 <?php
-declare(strict_types = 1);
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+declare (strict_types = 1);
 
 namespace ProophTest\Bundle\ServiceBus\DependencyInjection;
-
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/test/DependencyInjection/YamlServiceBusExtensionTest.php
+++ b/test/DependencyInjection/YamlServiceBusExtensionTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types = 1);
+
+namespace ProophTest\Bundle\ServiceBus\DependencyInjection;
+
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+class YamlServiceBusExtensionTest extends AbtractServiceBusExtensionTestCase
+{
+    protected function loadFromFile(ContainerBuilder $container, $file)
+    {
+        $loadYaml = new YamlFileLoader($container, new FileLocator(__DIR__.'/Fixture/config/yml'));
+        $loadYaml->load($file.'.yml');
+    }
+}


### PR DESCRIPTION
~~There are problems with XML config mapping.~~
- [x] XML Config for command bus 
- [x] XML Config for event bus
- [x] XML Config for query bus
- [x] YAML Config for command bus 
- [x] YAML Config for event bus
- [x] YAML Config for query bus
- [x] Fix compiler dump issues

The parsed command bus XML has the following structure:

``` php
        [
            'command_buses' =>
                [
                    'name' => 'main',
                    'message_factory' => 'Prooph\\Common\\Messaging\\MessageFactory',
                    'plugin' => 'Prooph\\ServiceBus\\Plugin\\InvokeStrategy\\OnEventStrategy',
                    'router' =>
                        [
                            'type' => 'Prooph\\ServiceBus\\Plugin\\Router\\CommandRouter',
                            'route' =>
                                [
                                    0 =>
                                        [
                                            'command' => 'Prooph\\ProophessorDo\\Model\\User\\Command\\RegisterUser',
                                            'value' => 'Prooph\\ProophessorDo\\Model\\User\\Handler\\RegisterUserHandler',
                                        ],
                                    1 =>
                                        [
                                            'command' => 'Prooph\\ProophessorDo\\Model\\User\\Command\\UpdateUser',
                                            'value' => 'Prooph\\ProophessorDo\\Model\\User\\Handler\\UpdateUserHandler',
                                        ],
                                ],
                        ],
                ],
        ];
```

but it must be

``` php
[
            'command_buses' =>
                [
                    'main' =>
                        [
                            'message_factory' => 'Prooph\\Common\\Messaging\\MessageFactory',
                            'router' =>
                                [
                                    'type' => 'Prooph\\ServiceBus\\Plugin\\Router\\CommandRouter',
                                    'routes' =>
                                        [
                                            'Prooph\\ProophessorDo\\Model\\User\\Command\\RegisterUser' => 'Prooph\\ProophessorDo\\Model\\User\\Handler\\RegisterUserHandler',
                                            'Prooph\\ProophessorDo\\Model\\User\\Command\\UpdateUser' => 'Prooph\\ProophessorDo\\Model\\User\\Handler\\UpdateUserHandler',
                                        ],
                                ],
                            'plugins' =>
                                [
                                    0 => 'Prooph\\ServiceBus\\Plugin\\InvokeStrategy\\OnEventStrategy',
                                ],
                        ],
                ],
        ]
```

`beforeNormalization()` can only be used at the beginning and not on the `routes` node. The XML does not match the structure and so an error occurs.
