### PR TITLE
Remove container->has check for plugins

### DIFF
--- a/src/DependencyInjection/ProophServiceBusExtension.php
+++ b/src/DependencyInjection/ProophServiceBusExtension.php
@@ -11,7 +11,6 @@ declare (strict_types = 1);
 
 namespace Prooph\Bundle\ServiceBus\DependencyInjection;
 
-use Prooph\Bundle\ServiceBus\Exception\RuntimeException;
 use Prooph\ServiceBus\CommandBus;
 use Prooph\ServiceBus\EventBus;
 use Prooph\ServiceBus\QueryBus;
@@ -128,13 +127,6 @@ final class ProophServiceBusExtension extends Extension
 
         if (!empty($options['plugins'])) {
             foreach ($options['plugins'] as $index => $util) {
-                if (!is_string($util) || !$container->has($util)) {
-                    throw new RuntimeException(sprintf(
-                        'Wrong message bus utility "%s" configured. It is unknown by the container.',
-                        $util
-                    ));
-                }
-
                 $serviceBusDefinition->addMethodCall('utilize', [new Reference($util)]);
             }
         }


### PR DESCRIPTION
Symfony container performs the check itself but seems to use another mechanism.
Anyway, the removed check fails for a plugin defined in a servies.yml. Without the
manual check loading the plugin works. A wrong service id causes symfony container to
fail with a similar message (dependency missing) so we can safely remove the check.
