### PR TITLE
Remove one ns level from generated bus service ids

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -39,9 +39,9 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('prooph_service_bus');
 
-        $this->addServiceBusSection('command', $rootNode);
-        $this->addServiceBusSection('event',  $rootNode);
-        $this->addServiceBusSection('query', $rootNode);
+        foreach (ProophServiceBusExtension::AVAILABLE_BUSES as $type => $class) {
+            $this->addServiceBusSection($type, $rootNode);
+        }
 
         return $treeBuilder;
     }
@@ -60,14 +60,14 @@ final class Configuration implements ConfigurationInterface
         $routesNode = $treeBuilder->root('routes');
 
         /** @var $routesNode ArrayNodeDefinition */
-        $listenerNode = $routesNode
+        $handlerNode = $routesNode
             ->requiresAtLeastOneElement()
             ->useAttributeAsKey($type)
             ->prototype('event' === $type ? 'array' : 'scalar')
         ;
 
         if ('event' === $type) {
-            $listenerNode
+            $handlerNode
                     ->beforeNormalization()
                         ->ifTrue(function ($v) {
                             // XML uses listener nodes

--- a/src/DependencyInjection/ProophServiceBusExtension.php
+++ b/src/DependencyInjection/ProophServiceBusExtension.php
@@ -161,7 +161,7 @@ final class ProophServiceBusExtension extends Extension
 
             $serviceBusDefinition->addMethodCall('utilize', [new Reference($routerId)]);
         }
-        
+
         //Add container plugin
         $serviceBusDefinition->addMethodCall('utilize', [new Reference('prooph_service_bus.container_plugin')]);
     }

--- a/src/Resources/config/service_bus.xml
+++ b/src/Resources/config/service_bus.xml
@@ -14,8 +14,12 @@
     <services>
         <service id="Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy" class="Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy" />
         <service id="prooph_service_bus.message_factory_plugin" class="%prooph_service_bus.message_factory_plugin.class%" public="false" abstract="true" />
-        <service id="prooph_service_bus.container_plugin" class="%prooph_service_bus.container_plugin.class%" public="false" abstract="true" />
-        <service id="prooph_service_bus.container_wrapper" class="%prooph_service_bus.container_wrapper.class%" public="false" abstract="true" />
         <service id="prooph_service_bus.message_factory" class="%prooph_service_bus.message_factory.class%" />
+        <service id="prooph_service_bus.container_plugin" class="%prooph_service_bus.container_plugin.class%" public="false">
+            <argument type="service" id="prooph_service_bus.container_wrapper" />
+        </service>
+        <service id="prooph_service_bus.container_wrapper" class="%prooph_service_bus.container_wrapper.class%" public="false">
+            <argument type="service" id="service_container" />
+        </service>
     </services>
 </container>

--- a/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
+++ b/test/DependencyInjection/AbtractServiceBusExtensionTestCase.php
@@ -40,16 +40,16 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
     {
         $container = $this->loadContainer('command_bus');
 
-        $config = $container->getDefinition('prooph_service_bus.command_bus.main_bus');
+        $config = $container->getDefinition('prooph_service_bus.main_command_bus');
 
         self::assertEquals(CommandBus::class, $config->getClass());
 
         /* @var $commandBus CommandBus */
-        $commandBus = $container->get('prooph_service_bus.command_bus.main_bus');
+        $commandBus = $container->get('prooph_service_bus.main_command_bus');
 
         self::assertInstanceOf(CommandBus::class, $commandBus);
 
-        $router = $container->get('prooph_service_bus.command_bus_router.main');
+        $router = $container->get('prooph_service_bus.main_command_bus.router');
 
         self::assertInstanceOf(CommandRouter::class, $router);
     }
@@ -61,17 +61,17 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
     {
         $container = $this->loadContainer('command_bus_multiple');
 
-        foreach (['main', 'second'] as $name) {
-            $config = $container->getDefinition('prooph_service_bus.command_bus.' . $name . '_bus');
+        foreach (['main_command_bus', 'second_command_bus'] as $name) {
+            $config = $container->getDefinition('prooph_service_bus.' . $name);
 
             self::assertEquals(CommandBus::class, $config->getClass());
 
             /* @var $commandBus CommandBus */
-            $commandBus = $container->get('prooph_service_bus.command_bus.' . $name . '_bus');
+            $commandBus = $container->get('prooph_service_bus.' . $name);
 
             self::assertInstanceOf(CommandBus::class, $commandBus);
 
-            $router = $container->get('prooph_service_bus.command_bus_router.main');
+            $router = $container->get('prooph_service_bus.'.$name.'.router');
 
             self::assertInstanceOf(CommandRouter::class, $router);
         }
@@ -93,7 +93,7 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
         $container = $this->loadContainer('command_bus');
 
         /* @var $commandBus CommandBus */
-        $commandBus = $container->get('prooph_service_bus.command_bus.main_bus');
+        $commandBus = $container->get('prooph_service_bus.main_command_bus');
 
         /** @var AcmeRegisterUserHandler $mockHandler */
         $mockHandler = $container->get('Acme\RegisterUserHandler');
@@ -112,16 +112,16 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
     {
         $container = $this->loadContainer('query_bus');
 
-        $config = $container->getDefinition('prooph_service_bus.query_bus.main_bus');
+        $config = $container->getDefinition('prooph_service_bus.main_query_bus');
 
         self::assertEquals(QueryBus::class, $config->getClass());
 
         /* @var $queryBus QueryBus */
-        $queryBus = $container->get('prooph_service_bus.query_bus.main_bus');
+        $queryBus = $container->get('prooph_service_bus.main_query_bus');
 
         self::assertInstanceOf(QueryBus::class, $queryBus);
 
-        $router = $container->get('prooph_service_bus.query_bus_router.main');
+        $router = $container->get('prooph_service_bus.main_query_bus.router');
 
         self::assertInstanceOf(QueryRouter::class, $router);
     }
@@ -133,17 +133,17 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
     {
         $container = $this->loadContainer('query_bus_multiple');
 
-        foreach (['main', 'second'] as $name) {
-            $config = $container->getDefinition('prooph_service_bus.query_bus.' . $name . '_bus');
+        foreach (['main_query_bus', 'second_query_bus'] as $name) {
+            $config = $container->getDefinition('prooph_service_bus.' . $name);
 
             self::assertEquals(QueryBus::class, $config->getClass());
 
             /* @var $queryBus QueryBus */
-            $queryBus = $container->get('prooph_service_bus.query_bus.' . $name . '_bus');
+            $queryBus = $container->get('prooph_service_bus.' . $name);
 
             self::assertInstanceOf(QueryBus::class, $queryBus);
 
-            $router = $container->get('prooph_service_bus.query_bus_router.main');
+            $router = $container->get('prooph_service_bus.'.$name.'.router');
 
             self::assertInstanceOf(QueryRouter::class, $router);
         }
@@ -164,16 +164,16 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
     {
         $container = $this->loadContainer('event_bus');
 
-        $config = $container->getDefinition('prooph_service_bus.event_bus.main_bus');
+        $config = $container->getDefinition('prooph_service_bus.main_event_bus');
 
         self::assertEquals(EventBus::class, $config->getClass());
 
         /* @var $eventBus EventBus */
-        $eventBus = $container->get('prooph_service_bus.event_bus.main_bus');
+        $eventBus = $container->get('prooph_service_bus.main_event_bus');
 
         self::assertInstanceOf(EventBus::class, $eventBus);
 
-        $router = $container->get('prooph_service_bus.event_bus_router.main');
+        $router = $container->get('prooph_service_bus.main_event_bus.router');
 
         self::assertInstanceOf(EventRouter::class, $router);
     }
@@ -186,17 +186,17 @@ abstract class AbtractServiceBusExtensionTestCase extends TestCase
         $container = $this->loadContainer('event_bus_multiple');
 
 
-        foreach (['main', 'second'] as $name) {
-            $config = $container->getDefinition('prooph_service_bus.event_bus.' . $name . '_bus');
+        foreach (['main_event_bus', 'second_event_bus'] as $name) {
+            $config = $container->getDefinition('prooph_service_bus.' . $name);
 
             self::assertEquals(EventBus::class, $config->getClass());
 
             /* @var $eventBus EventBus */
-            $eventBus = $container->get('prooph_service_bus.event_bus.' . $name . '_bus');
+            $eventBus = $container->get('prooph_service_bus.' . $name);
 
             self::assertInstanceOf(EventBus::class, $eventBus);
 
-            $router = $container->get('prooph_service_bus.event_bus_router.main');
+            $router = $container->get('prooph_service_bus.'.$name.'.router');
 
             self::assertInstanceOf(EventRouter::class, $router);
         }

--- a/test/DependencyInjection/Fixture/config/xml/command_bus.xml
+++ b/test/DependencyInjection/Fixture/config/xml/command_bus.xml
@@ -7,7 +7,7 @@
                         http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
 
     <config>
-        <command_bus name="main" message_factory="prooph_service_bus.message_factory">
+        <command_bus name="main_command_bus" message_factory="prooph_service_bus.message_factory">
             <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
             <router type="prooph_service_bus.command_bus_router">
                 <route command="Acme\RegisterUser">Acme\RegisterUserHandler</route>

--- a/test/DependencyInjection/Fixture/config/xml/command_bus_multiple.xml
+++ b/test/DependencyInjection/Fixture/config/xml/command_bus_multiple.xml
@@ -7,7 +7,7 @@
                         http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
 
     <config>
-        <command_bus name="main" message_factory="prooph_service_bus.message_factory">
+        <command_bus name="main_command_bus" message_factory="prooph_service_bus.message_factory">
             <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
             <router type="prooph_service_bus.command_bus_router">
                 <route command="Prooph\ProophessorDo\Model\User\Command\RegisterUser">Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler</route>
@@ -15,7 +15,7 @@
             </router>
         </command_bus>
         <!-- uses default values -->
-        <command_bus name="second">
+        <command_bus name="second_command_bus">
             <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
             <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
             <router>

--- a/test/DependencyInjection/Fixture/config/xml/event_bus.xml
+++ b/test/DependencyInjection/Fixture/config/xml/event_bus.xml
@@ -6,7 +6,7 @@
                xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
     <config>
-        <event_bus name="main" message_factory="prooph_service_bus.message_factory">
+        <event_bus name="main_event_bus" message_factory="prooph_service_bus.message_factory">
             <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
             <router type="prooph_service_bus.event_bus_router">
                 <route event="Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted">

--- a/test/DependencyInjection/Fixture/config/xml/event_bus_multiple.xml
+++ b/test/DependencyInjection/Fixture/config/xml/event_bus_multiple.xml
@@ -6,7 +6,7 @@
                xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
     <config>
-        <event_bus name="main" message_factory="prooph_service_bus.message_factory">
+        <event_bus name="main_event_bus" message_factory="prooph_service_bus.message_factory">
             <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
             <router type="prooph_service_bus.event_bus_router">
                 <route event="Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted">
@@ -15,7 +15,7 @@
             </router>
         </event_bus>
         <!-- uses default values -->
-        <event_bus name="second">
+        <event_bus name="second_event_bus">
             <router>
                 <route event="Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted">
                     <listener>Prooph\ProophessorDo\Projection\Todo\TodoProjector</listener>

--- a/test/DependencyInjection/Fixture/config/xml/query_bus.xml
+++ b/test/DependencyInjection/Fixture/config/xml/query_bus.xml
@@ -7,7 +7,7 @@
                         http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
 
     <config>
-        <query_bus name="main" message_factory="prooph_service_bus.message_factory">
+        <query_bus name="main_query_bus" message_factory="prooph_service_bus.message_factory">
             <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
             <router type="prooph_service_bus.query_bus_router">
                 <route query="Prooph\ProophessorDo\Model\User\Query\UserList">

--- a/test/DependencyInjection/Fixture/config/xml/query_bus_multiple.xml
+++ b/test/DependencyInjection/Fixture/config/xml/query_bus_multiple.xml
@@ -7,7 +7,7 @@
                         http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
 
     <config>
-        <query_bus name="main" message_factory="prooph_service_bus.message_factory">
+        <query_bus name="main_query_bus" message_factory="prooph_service_bus.message_factory">
             <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
             <router type="prooph_service_bus.query_bus_router">
                 <route query="Prooph\ProophessorDo\Model\User\Query\UserList">Prooph\ProophessorDo\Model\User\Query\UserListUserHandler</route>
@@ -15,7 +15,7 @@
             </router>
         </query_bus>
         <!-- uses default values -->
-        <query_bus name="second">
+        <query_bus name="second_query_bus">
             <router>
                 <route query="Prooph\ProophessorDo\Model\User\Query\UserList">Prooph\ProophessorDo\Model\User\Query\UserListUserHandler</route>
                 <route query="Prooph\ProophessorDo\Model\Todo\Query\TodoList">Prooph\ProophessorDo\Model\User\Query\TodoListHandler</route>

--- a/test/DependencyInjection/Fixture/config/yml/command_bus.yml
+++ b/test/DependencyInjection/Fixture/config/yml/command_bus.yml
@@ -1,6 +1,6 @@
 prooph_service_bus:
   command_buses:
-    main:
+    main_command_bus:
       message_factory: 'prooph_service_bus.message_factory'
       router:
         type: 'prooph_service_bus.command_bus_router'

--- a/test/DependencyInjection/Fixture/config/yml/command_bus_multiple.yml
+++ b/test/DependencyInjection/Fixture/config/yml/command_bus_multiple.yml
@@ -1,6 +1,6 @@
 prooph_service_bus:
   command_buses:
-    main:
+    main_command_bus:
       message_factory: 'prooph_service_bus.message_factory'
       router:
         type: 'prooph_service_bus.command_bus_router'
@@ -9,7 +9,7 @@ prooph_service_bus:
           'Prooph\ProophessorDo\Model\User\Command\UpdateUser': 'Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler'
 
     # uses default values
-    second:
+    second_command_bus:
       router:
         routes:
           'Prooph\ProophessorDo\Model\User\Command\RegisterUser': 'Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler'

--- a/test/DependencyInjection/Fixture/config/yml/event_bus.yml
+++ b/test/DependencyInjection/Fixture/config/yml/event_bus.yml
@@ -1,6 +1,6 @@
 prooph_service_bus:
   event_buses:
-    main:
+    main_event_bus:
       plugins:
         - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
       message_factory: 'prooph_service_bus.message_factory'

--- a/test/DependencyInjection/Fixture/config/yml/event_bus_multiple.yml
+++ b/test/DependencyInjection/Fixture/config/yml/event_bus_multiple.yml
@@ -1,6 +1,6 @@
 prooph_service_bus:
   event_buses:
-    main:
+    main_event_bus:
       message_factory: 'prooph_service_bus.message_factory'
       router:
         type: 'prooph_service_bus.event_bus_router'
@@ -12,7 +12,7 @@ prooph_service_bus:
         - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
 
     # uses default values
-    second:
+    second_event_bus:
       plugins:
         - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
       router:

--- a/test/DependencyInjection/Fixture/config/yml/query_bus.yml
+++ b/test/DependencyInjection/Fixture/config/yml/query_bus.yml
@@ -1,6 +1,6 @@
 prooph_service_bus:
   query_buses:
-    main:
+    main_query_bus:
       message_factory: 'prooph_service_bus.message_factory'
       router:
         type: 'prooph_service_bus.query_bus_router'

--- a/test/DependencyInjection/Fixture/config/yml/query_bus_multiple.yml
+++ b/test/DependencyInjection/Fixture/config/yml/query_bus_multiple.yml
@@ -1,6 +1,6 @@
 prooph_service_bus:
   query_buses:
-    main:
+    main_query_bus:
       message_factory: 'prooph_service_bus.message_factory'
       router:
         type: 'prooph_service_bus.query_bus_router'
@@ -9,7 +9,7 @@ prooph_service_bus:
           'Prooph\ProophessorDo\Model\Todo\Query\TodoList': 'Prooph\ProophessorDo\Model\User\Query\TodoListHandler'
 
     # uses default values
-    second:
+    second_query_bus:
       router:
         routes:
           'Prooph\ProophessorDo\Model\User\Query\UserList': 'Prooph\ProophessorDo\Model\User\Query\UserListUserHandler'


### PR DESCRIPTION
Before: prooph_service_bus.command_bus._user_defined_name__bus
Now: prooph_service_bus._user_defined_name_

Router of the bus is now referenced like this:
prooph_service_bus._user_defined_name_.router
