### PR TITLE
Add tagging support for plugins

### DIFF
--- a/src/DependencyInjection/Compiler/PluginsPass.php
+++ b/src/DependencyInjection/Compiler/PluginsPass.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+declare (strict_types = 1);
+
+namespace Prooph\Bundle\ServiceBus\DependencyInjection\Compiler;
+
+use Prooph\Bundle\ServiceBus\DependencyInjection\ProophServiceBusExtension;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class PluginsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach (ProophServiceBusExtension::AVAILABLE_BUSES as $type => $busClass) {
+            if (!$container->hasParameter('prooph_service_bus.' . $type . '_buses')) {
+                continue;
+            }
+
+            $buses = $container->getParameter('prooph_service_bus.' . $type . '_buses');
+
+            foreach ($buses as $name => $bus) {
+                $globalPlugins = $container->findTaggedServiceIds('prooph_service_bus.plugin');
+                $typePlugins = $container->findTaggedServiceIds(sprintf('prooph_service_bus.%s.plugin', $type . '_bus'));
+                $plugins = $container->findTaggedServiceIds(sprintf('prooph_service_bus.%s.plugin', $name));
+
+                $plugins = array_merge($globalPlugins, $typePlugins, $plugins);
+
+                foreach ($plugins as $id => $args) {
+                    $definition = $container->findDefinition('prooph_service_bus.' . $name);
+                    $definition->addMethodCall('utilize', [new Reference($id)]);
+                }
+            }
+        }
+    }
+}

--- a/src/ProophServiceBusBundle.php
+++ b/src/ProophServiceBusBundle.php
@@ -11,6 +11,7 @@ declare (strict_types = 1);
 
 namespace Prooph\Bundle\ServiceBus;
 
+use Prooph\Bundle\ServiceBus\DependencyInjection\Compiler\PluginsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -19,7 +20,6 @@ final class ProophServiceBusBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
-
-        // TODO RegisterEventListenersAndSubscribersPass like doctrine ?
+        $container->addCompilerPass(new PluginsPass());
     }
 }

--- a/test/DependencyInjection/Fixture/Model/CommandTypePlugin.php
+++ b/test/DependencyInjection/Fixture/Model/CommandTypePlugin.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+declare (strict_types = 1);
+
+namespace ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model;
+
+final class CommandTypePlugin extends MockPlugin
+{
+}

--- a/test/DependencyInjection/Fixture/Model/GlobalPlugin.php
+++ b/test/DependencyInjection/Fixture/Model/GlobalPlugin.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+declare (strict_types = 1);
+
+namespace ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model;
+
+final class GlobalPlugin extends MockPlugin
+{
+}

--- a/test/DependencyInjection/Fixture/Model/MainCommandBusPlugin.php
+++ b/test/DependencyInjection/Fixture/Model/MainCommandBusPlugin.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+declare (strict_types = 1);
+
+namespace ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model;
+
+final class MainCommandBusPlugin extends MockPlugin
+{
+}

--- a/test/DependencyInjection/Fixture/Model/MockPlugin.php
+++ b/test/DependencyInjection/Fixture/Model/MockPlugin.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+declare (strict_types = 1);
+
+namespace ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model;
+
+use Prooph\Common\Event\ActionEvent;
+use Prooph\Common\Event\ActionEventEmitter;
+use Prooph\Common\Event\ActionEventListenerAggregate;
+use Prooph\Common\Event\DetachAggregateHandlers;
+use Prooph\ServiceBus\MessageBus;
+
+class MockPlugin implements ActionEventListenerAggregate
+{
+    use DetachAggregateHandlers;
+
+    private $fired = false;
+
+    public function wasFired(): bool
+    {
+        return $this->fired;
+    }
+
+    /**
+     * @param ActionEventEmitter $dispatcher
+     */
+    public function attach(ActionEventEmitter $dispatcher)
+    {
+        $this->trackHandler($dispatcher->attachListener(MessageBus::EVENT_INITIALIZE, [$this, 'onInitialize']));
+    }
+
+    public function onInitialize(ActionEvent $event)
+    {
+        $this->fired = true;
+    }
+
+    public function reset()
+    {
+        $this->fired = false;
+    }
+}

--- a/test/DependencyInjection/Fixture/config/xml/plugins.xml
+++ b/test/DependencyInjection/Fixture/config/xml/plugins.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
+
+    <config>
+        <command_bus name="main_command_bus" message_factory="prooph_service_bus.message_factory">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <router type="prooph_service_bus.command_bus_router">
+                <route command="Prooph\ProophessorDo\Model\User\Command\RegisterUser">Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler</route>
+                <route command="Prooph\ProophessorDo\Model\User\Command\UpdateUser">Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler</route>
+            </router>
+        </command_bus>
+        <!-- uses default values -->
+        <command_bus name="second_command_bus">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <router>
+                <route command="Prooph\ProophessorDo\Model\User\Command\RegisterUser">Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler</route>
+                <route command="Prooph\ProophessorDo\Model\User\Command\UpdateUser">Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler</route>
+            </router>
+        </command_bus>
+
+        <event_bus name="main_event_bus" message_factory="prooph_service_bus.message_factory">
+            <plugin>Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy</plugin>
+            <router type="prooph_service_bus.event_bus_router">
+                <route event="Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted">
+                    <listener>Prooph\ProophessorDo\Projection\Todo\TodoProjector</listener>
+                    <listener>Prooph\ProophessorDo\Projection\Todo\UserProjector</listener>
+                </route>
+            </router>
+        </event_bus>
+    </config>
+
+    <srv:services>
+        <srv:service id="global_plugin" class="ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\GlobalPlugin">
+            <srv:tag name="prooph_service_bus.plugin" />
+        </srv:service>
+        <srv:service id="command_type_plugin" class="ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\CommandTypePlugin">
+            <srv:tag name="prooph_service_bus.command_bus.plugin" />
+        </srv:service>
+        <srv:service id="main_command_bus_plugin" class="ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\MainCommandBusPlugin">
+            <srv:tag name="prooph_service_bus.main_command_bus.plugin" />
+        </srv:service>
+    </srv:services>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/yml/plugins.yml
+++ b/test/DependencyInjection/Fixture/config/yml/plugins.yml
@@ -1,0 +1,44 @@
+prooph_service_bus:
+  command_buses:
+    main_command_bus:
+      message_factory: 'prooph_service_bus.message_factory'
+      router:
+        type: 'prooph_service_bus.command_bus_router'
+        routes:
+          'Prooph\ProophessorDo\Model\User\Command\RegisterUser': 'Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler'
+          'Prooph\ProophessorDo\Model\User\Command\UpdateUser': 'Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler'
+
+    # uses default values
+    second_command_bus:
+      router:
+        routes:
+          'Prooph\ProophessorDo\Model\User\Command\RegisterUser': 'Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler'
+          'Prooph\ProophessorDo\Model\User\Command\UpdateUser': 'Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler'
+
+  event_buses:
+    main_event_bus:
+      plugins:
+        - 'Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy'
+      message_factory: 'prooph_service_bus.message_factory'
+      router:
+        type: 'prooph_service_bus.event_bus_router'
+        routes:
+          'Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted':
+            - 'Prooph\ProophessorDo\Projection\Todo\TodoProjector'
+            - 'Prooph\ProophessorDo\Projection\User\UserProjector'
+
+services:
+  'global_plugin':
+    class: 'ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\GlobalPlugin'
+    tags:
+      - { name: prooph_service_bus.plugin }
+
+  'command_type_plugin':
+      class: 'ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\CommandTypePlugin'
+      tags:
+        - { name: prooph_service_bus.command_bus.plugin }
+
+  'main_command_bus_plugin':
+      class: 'ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\MainCommandBusPlugin'
+      tags:
+        - { name: prooph_service_bus.main_command_bus.plugin }


### PR DESCRIPTION
Plugins with a prooph_service_bus.plugin tag are attached to all buses.
Plugins with a prooph_service_bus._type__bus.plugin are attached to all type buses.
Plugins with a prooph_service_bus._user_defined_bus_name_.plugin are attached to those buses only.
