### PR TITLE
minimize necessary configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -142,6 +142,7 @@ final class Configuration implements ConfigurationInterface
                     ->end()
                     ->arrayNode('router')
                         ->fixXmlConfig('route', 'routes')
+                        ->addDefaultsIfNotSet()
                         ->children()
                             ->scalarNode('type')
                                 ->beforeNormalization()

--- a/test/DependencyInjection/AbstractServiceBusExtensionTestCase.php
+++ b/test/DependencyInjection/AbstractServiceBusExtensionTestCase.php
@@ -63,6 +63,16 @@ abstract class AbstractServiceBusExtensionTestCase extends TestCase
     /**
      * @test
      */
+    public function it_allows_a_minimal_bus_configuration()
+    {
+        $container = $this->loadContainer('command_bus_minimal');
+        self::assertInstanceOf(CommandBus::class, $container->get('prooph_service_bus.main_command_bus'));
+        self::assertInstanceOf(CommandRouter::class, $container->get('prooph_service_bus.main_command_bus.router'));
+    }
+
+    /**
+     * @test
+     */
     public function it_creates_multiple_command_buses()
     {
         $container = $this->loadContainer('command_bus_multiple');

--- a/test/DependencyInjection/Fixture/config/xml/command_bus_minimal.xml
+++ b/test/DependencyInjection/Fixture/config/xml/command_bus_minimal.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
+
+    <config>
+        <command_bus name="main_command_bus" />
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/yml/command_bus_minimal.yml
+++ b/test/DependencyInjection/Fixture/config/yml/command_bus_minimal.yml
@@ -1,0 +1,3 @@
+prooph_service_bus:
+  command_buses:
+    main_command_bus: ~


### PR DESCRIPTION
While writing the documentation I tried some code samples and recognized that this minimalistic configuration does not work because it doesn't initialize a router:
```yaml
prooph_service_bus:
    command_buses:
        acme_command_bus: ~
```

But with the latest changes most things can be configured using tags and so there will be no additional router configuration necessary in most cases. Therefore allowing an empty router configuration which falls back to the default values would make sense.