### PR TITLE
MessageBusFactory cannot access private service

### DIFF
--- a/src/DependencyInjection/ProophServiceBusExtension.php
+++ b/src/DependencyInjection/ProophServiceBusExtension.php
@@ -146,6 +146,7 @@ final class ProophServiceBusExtension extends Extension
         $messageFactoryPluginId = 'prooph_service_bus.message_factory_plugin.'.$name;
         $messageFactoryPluginDefinition = new DefinitionDecorator('prooph_service_bus.message_factory_plugin');
         $messageFactoryPluginDefinition->setArguments([new Reference($messageFactoryId)]);
+        $messageFactoryPluginDefinition->setPublic(true);
 
         $container->setDefinition(
                 $messageFactoryPluginId,
@@ -159,6 +160,7 @@ final class ProophServiceBusExtension extends Extension
             $routerId = 'prooph_service_bus.' . $name . '.router';
             $routerDefinition = new DefinitionDecorator($options['router']['type']);
             $routerDefinition->setArguments([$options['router']['routes'] ?? []]);
+            $routerDefinition->setPublic(true);
             $container->setDefinition($routerId, $routerDefinition);
         }
 

--- a/src/Resources/config/service_bus.xml
+++ b/src/Resources/config/service_bus.xml
@@ -18,7 +18,7 @@
         <service id="prooph_service_bus.on_event_invoke_strategy" class="Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy" />
         <service id="prooph_service_bus.message_factory_plugin" class="%prooph_service_bus.message_factory_plugin.class%" public="false" abstract="true" />
         <service id="prooph_service_bus.message_factory" class="%prooph_service_bus.message_factory.class%" />
-        <service id="prooph_service_bus.container_plugin" class="%prooph_service_bus.container_plugin.class%" public="false">
+        <service id="prooph_service_bus.container_plugin" class="%prooph_service_bus.container_plugin.class%">
             <argument type="service" id="prooph_service_bus.container_wrapper" />
         </service>
         <service id="prooph_service_bus.container_wrapper" class="%prooph_service_bus.container_wrapper.class%" public="false">


### PR DESCRIPTION
In the MessageBusFactory the container is accessed via get(). 
```php
 foreach ($plugins as $pluginId) {
            $plugin = $container->get($pluginId);
            $plugin->attachToMessageBus($bus);
        }
```
The `prooph_service_bus.container_plugin` is marked private,thus cannot be accessed. This PR removes the "public=false" attribute. Any specific reason to keep it private?

Same for message factory plugins and router plugins