### PR TITLE
Remove requiring always have at least one target

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -61,7 +61,6 @@ final class Configuration implements ConfigurationInterface
 
         /** @var $routesNode ArrayNodeDefinition */
         $handlerNode = $routesNode
-            ->requiresAtLeastOneElement()
             ->useAttributeAsKey($type)
             ->prototype('event' === $type ? 'array' : 'scalar');
 


### PR DESCRIPTION
When you configure a service bus you always need(ed) to have at least one target for the router, however this makes working with tagged services much harder.

And technically there is no requirement for this, as you can use a custom plugin to set a resolved handler and the router will simple ignore this.