### PR TITLE
Updates Symfony dependencies to 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,9 +57,9 @@
   },
   "require": {
     "php": "^7.1",
-    "symfony/config": "~2.8 || ~3.0",
-    "symfony/dependency-injection": "~2.8 || ~3.0",
-    "symfony/http-kernel": "~2.8 || ~3.0",
+    "symfony/config": "~3.3",
+    "symfony/dependency-injection": "~3.3",
+    "symfony/http-kernel": "~3.3",
     "prooph/service-bus": "~6.0",
     "psr/container": "^1.0"
   },


### PR DESCRIPTION
The refactor from September 29th started using `ChildDefinition` which wasn't introduced until Symfony 3.3