### PR TITLE
Fix Compiler\RoutePass, routers may not have handler=>class mapping as first argument.

### DIFF
--- a/src/DependencyInjection/Compiler/RoutePass.php
+++ b/src/DependencyInjection/Compiler/RoutePass.php
@@ -76,7 +76,11 @@ class RoutePass implements CompilerPassInterface
                 // Update route configuration parameter
                 $configId = sprintf('prooph_service_bus.%s.configuration', $name);
 
-                $config = array_replace($container->getParameter($configId), ['router' => ['routes' => $routerArguments[0]]]);
+                $config = $container->getParameter($configId);
+
+                if ($router instanceof ChildDefinition && is_a($container->getDefinition($router->getParent())->getClass(), SingleHandlerRouter::class, true)) {
+                    $config = array_replace($config, ['router' => ['routes' => $routerArguments[0]]]);
+                }
 
                 $config = $container->setParameter($configId, $config);
             }

--- a/test/DependencyInjection/AbstractServiceBusExtensionTestCase.php
+++ b/test/DependencyInjection/AbstractServiceBusExtensionTestCase.php
@@ -32,6 +32,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\Dumper;
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Dumper\XmlDumper;
 use Symfony\Component\DependencyInjection\Dumper\YamlDumper;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -405,6 +406,14 @@ abstract class AbstractServiceBusExtensionTestCase extends TestCase
         self::assertInstanceOf(AsyncSwitchMessageRouter::class, $router);
     }
 
+    /**
+     * @test
+     */
+    public function it_dumps_async_switch_command_bus()
+    {
+        $this->dump('command_bus_async');
+    }
+
     private function loadContainer($fixture, CompilerPassInterface ...$compilerPasses)
     {
         $container = $this->getContainer();
@@ -449,7 +458,7 @@ abstract class AbstractServiceBusExtensionTestCase extends TestCase
 
     private function dump(string $configFile)
     {
-        $container = $this->loadContainer($configFile);
+        $container = $this->loadContainer($configFile, new PluginsPass(), new RoutePass());
         $dumper = null;
 
         if ($this instanceof XmlServiceBusExtensionTest) {
@@ -459,5 +468,7 @@ abstract class AbstractServiceBusExtensionTestCase extends TestCase
         }
         self::assertInstanceOf(Dumper::class, $dumper, sprintf('Test type "%s" not supported', get_class($this)));
         self::assertNotEmpty($dumper->dump());
+
+        self::assertNotEmpty((new PhpDumper($container))->dump(), 'PHP cache cannot be warmuped correctly.');
     }
 }


### PR DESCRIPTION
Config to reproduce the bug:

```
prooph_service_bus:
  command_buses:
    asynchronous_command_bus:
      router:
        async_switch: 'my_message_producer'
        routes: []
```

In RoutePass, it add 1st argument of router into the symfony container and since that's a dependency injection objects (references), it breaks the symfony container build.

With this fix, it add 1st argument only if service inherits from `SingleHandlerRouter`