### PR TITLE
Fix router parameters for data collector.

### DIFF
--- a/src/DependencyInjection/Compiler/RoutePass.php
+++ b/src/DependencyInjection/Compiler/RoutePass.php
@@ -76,13 +76,10 @@ class RoutePass implements CompilerPassInterface
                 // Update route configuration parameter
                 $configId = sprintf('prooph_service_bus.%s.configuration', $name);
 
-                $config = $container->getParameter($configId);
+                $routes = is_array($routerArguments[0]) ? $routerArguments[0] : [];
+                $config = array_replace($container->getParameter($configId), ['router' => ['routes' => $routes]]);
 
-                if ($router instanceof ChildDefinition && is_a($container->getDefinition($router->getParent())->getClass(), SingleHandlerRouter::class, true)) {
-                    $config = array_replace($config, ['router' => ['routes' => $routerArguments[0]]]);
-                }
-
-                $config = $container->setParameter($configId, $config);
+                $container->setParameter($configId, $config);
             }
         }
     }


### PR DESCRIPTION
Hi,

I'm sorry, I introduced an error in my previous PR (https://github.com/prooph/service-bus-symfony-bundle/commit/639253d752a70ab1d51ee13ecee5d11a2ded90bf). I fixed the async bus but it was not the good way ...
It doesn't work because in PHP we can't easily know if a class (as string) inherits from an other class. Whatever, its first argument could be something else than a mapping array.

In this PR, I just test if the first argument is an array, it fixes the issue but it's still not the best way to do in my opinion.
Since we are not able to be sure than argument/method from router will return an array[class=>handler] (with an interface ?), there is no perfect solution.

I guess we could merge this one (to fix datacollector export) then keep in mind we could find a better solution for the future ...

🍻 