### PR TITLE
Autoconfigure the Stopwatch plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,8 @@
     "phpspec/prophecy": "^1.7",
     "react/promise": "^2.5",
     "friendsofphp/php-cs-fixer": " ~2.0",
-    "prooph/php-cs-fixer-config": "^0.1.1"
+    "prooph/php-cs-fixer-config": "^0.1.1",
+    "symfony/framework-bundle": "~3.3"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/src/DependencyInjection/Compiler/StopwatchPass.php
+++ b/src/DependencyInjection/Compiler/StopwatchPass.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2017 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\Bundle\ServiceBus\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * The Stopwatch Plugin requires the Stopwatch service from the FrameworkBundle.
+ *
+ * If such service is not registered, we have to de-register the plugin.
+ */
+class StopwatchPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->hasDefinition('prooph_service_bus.plugin.stopwatch')
+            && ! $container->hasDefinition('debug.stopwatch')
+        ) {
+            $container->removeDefinition('prooph_service_bus.plugin.stopwatch');
+        }
+    }
+}

--- a/src/DependencyInjection/ProophServiceBusExtension.php
+++ b/src/DependencyInjection/ProophServiceBusExtension.php
@@ -135,7 +135,6 @@ final class ProophServiceBusExtension extends Extension
             ->addTag('monolog.logger', ['channel' => sprintf('%s_bus.%s', $type, $name)])
             ->addTag(sprintf('prooph_service_bus.%s.plugin', $name));
 
-
         // define message factory
         $messageFactoryId = 'prooph_service_bus.message_factory.' . $name;
         $container->setDefinition($messageFactoryId, new ChildDefinition($options['message_factory']));

--- a/src/DependencyInjection/ProophServiceBusExtension.php
+++ b/src/DependencyInjection/ProophServiceBusExtension.php
@@ -49,6 +49,10 @@ final class ProophServiceBusExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('service_bus.xml');
 
+        if ($container->getParameter('kernel.debug')) {
+            $loader->load('debug.xml');
+        }
+
         foreach (self::AVAILABLE_BUSES as $type) {
             if (! empty($config[$type . '_buses'])) {
                 $this->busLoad($type, $config[$type . '_buses'], $container, $loader);
@@ -131,23 +135,18 @@ final class ProophServiceBusExtension extends Extension
             ->addTag('monolog.logger', ['channel' => sprintf('%s_bus.%s', $type, $name)])
             ->addTag(sprintf('prooph_service_bus.%s.plugin', $name));
 
+
         // define message factory
-        $messageFactoryId = 'prooph_service_bus.message_factory.'.$name;
-        $container->setDefinition(
-                $messageFactoryId,
-                new ChildDefinition($options['message_factory'])
-            );
+        $messageFactoryId = 'prooph_service_bus.message_factory.' . $name;
+        $container->setDefinition($messageFactoryId, new ChildDefinition($options['message_factory']));
 
         // define message factory plugin
-        $messageFactoryPluginId = 'prooph_service_bus.message_factory_plugin.'.$name;
+        $messageFactoryPluginId = 'prooph_service_bus.message_factory_plugin.' . $name;
         $messageFactoryPluginDefinition = new ChildDefinition('prooph_service_bus.message_factory_plugin');
         $messageFactoryPluginDefinition->setArguments([new Reference($messageFactoryId)]);
         $messageFactoryPluginDefinition->addTag(sprintf('prooph_service_bus.%s.plugin', $name));
 
-        $container->setDefinition(
-                $messageFactoryPluginId,
-                $messageFactoryPluginDefinition
-            );
+        $container->setDefinition($messageFactoryPluginId, $messageFactoryPluginDefinition);
 
         // define router
         $routerId = null;

--- a/src/ProophServiceBusBundle.php
+++ b/src/ProophServiceBusBundle.php
@@ -13,6 +13,7 @@ namespace Prooph\Bundle\ServiceBus;
 
 use Prooph\Bundle\ServiceBus\DependencyInjection\Compiler\PluginsPass;
 use Prooph\Bundle\ServiceBus\DependencyInjection\Compiler\RoutePass;
+use Prooph\Bundle\ServiceBus\DependencyInjection\Compiler\StopwatchPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -21,6 +22,7 @@ final class ProophServiceBusBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+        $container->addCompilerPass(new StopwatchPass());
         $container->addCompilerPass(new PluginsPass());
         $container->addCompilerPass(new RoutePass());
     }

--- a/src/Resources/config/debug.xml
+++ b/src/Resources/config/debug.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="prooph_service_bus.plugin.stopwatch" class="Prooph\Bundle\ServiceBus\Plugin\StopwatchPlugin" public="false">
+            <argument id="debug.stopwatch" type="service"/>
+            <tag name="prooph_service_bus.plugin"/>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/service_bus.xml
+++ b/src/Resources/config/service_bus.xml
@@ -20,12 +20,6 @@
 
         <service id="prooph_service_bus.plugin.psr_logger" class="Prooph\Bundle\ServiceBus\Plugin\PsrLoggerPlugin" abstract="true" public="false"/>
 
-        <!--
-        <service id="prooph_service_bus.plugin.stopwatch" class="Prooph\Bundle\ServiceBus\Plugin\StopwatchPlugin" public="false">
-            <argument id="debug.stopwatch" type="service"/>
-            <tag name="prooph_service_bus.plugin" />
-        </service>
-        -->
         <service id="prooph_service_bus.async_switch_message_router" class="Prooph\ServiceBus\Plugin\Router\AsyncSwitchMessageRouter" />
     </services>
 </container>

--- a/test/DependencyInjection/ContainerBuilder.php
+++ b/test/DependencyInjection/ContainerBuilder.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\FileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
+/** @internal */
 class ContainerBuilder
 {
     /** @var FileLoader */

--- a/test/DependencyInjection/ContainerBuilder.php
+++ b/test/DependencyInjection/ContainerBuilder.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/prooph/service-bus-symfony-bundle for the canonical source repository
+ * @copyright Copyright (c) 2017 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/prooph/service-bus-symfony-bundle/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\Bundle\ServiceBus\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\FileLoader;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use function array_merge;
+use function array_walk;
+use function call_user_func;
+
+class ContainerBuilder
+{
+    /** @var FileLoader */
+    private $fileLoaderFactory;
+
+    /** @var string */
+    private $fileExtension;
+
+    /** @var array[] */
+    private $parameters;
+
+    /** @var ExtensionInterface[] */
+    private $extensions = [];
+
+    /** @var CompilerPassInterface[] */
+    private $compilerPasses = [];
+
+    /** @var string[] */
+    private $configFiles = [];
+
+    public static function buildContainer(callable $fileLoaderFactory, string $fileExtension): self
+    {
+        return new self($fileLoaderFactory, $fileExtension);
+    }
+
+    private function __construct(callable $fileLoaderFactory, string $fileExtension)
+    {
+        $this->fileLoaderFactory = $fileLoaderFactory;
+        $this->fileExtension = $fileExtension;
+        $this->parameters = [
+            'kernel.debug' => false,
+            'kernel.bundles' => [],
+            'kernel.cache_dir' => sys_get_temp_dir(),
+            'kernel.environment' => 'test',
+            'kernel.root_dir' => __DIR__ . '/../../src',
+        ];
+    }
+
+    public function withParameters(array $parameters): self
+    {
+        $this->parameters = array_merge($this->parameters, $parameters);
+        return $this;
+    }
+
+    public function withExtensions(ExtensionInterface ...$extensions): self
+    {
+        $this->extensions = array_merge($this->extensions, $extensions);
+        return $this;
+    }
+
+    public function withCompilerPasses(CompilerPassInterface ...$compilerPasses): self
+    {
+        $this->compilerPasses = array_merge($this->compilerPasses, $compilerPasses);
+        return $this;
+    }
+
+    public function withConfigFiles(string ...$fileNames): self
+    {
+        $this->configFiles = array_merge($this->configFiles, $fileNames);
+        return $this;
+    }
+
+    public function compile(): SymfonyContainerBuilder
+    {
+        $container = new SymfonyContainerBuilder(new ParameterBag($this->parameters));
+        array_walk($this->extensions, [$container, 'registerExtension']);
+
+        $fileLoader = call_user_func($this->fileLoaderFactory, $container);
+        array_walk($this->configFiles, function (string $fileName) use ($fileLoader) {
+            $fileLoader->load("$fileName.{$this->fileExtension}");
+        });
+
+        // array_walk is impossible here because the key will be passed as second parameter
+        array_map([$container, 'addCompilerPass'], $this->compilerPasses);
+
+        $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveDefinitionTemplatesPass()]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->compile();
+        return $container;
+    }
+}

--- a/test/DependencyInjection/ContainerBuilder.php
+++ b/test/DependencyInjection/ContainerBuilder.php
@@ -17,9 +17,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBu
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\FileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
-use function array_merge;
-use function array_walk;
-use function call_user_func;
 
 class ContainerBuilder
 {
@@ -62,24 +59,28 @@ class ContainerBuilder
     public function withParameters(array $parameters): self
     {
         $this->parameters = array_merge($this->parameters, $parameters);
+
         return $this;
     }
 
     public function withExtensions(ExtensionInterface ...$extensions): self
     {
         $this->extensions = array_merge($this->extensions, $extensions);
+
         return $this;
     }
 
     public function withCompilerPasses(CompilerPassInterface ...$compilerPasses): self
     {
         $this->compilerPasses = array_merge($this->compilerPasses, $compilerPasses);
+
         return $this;
     }
 
     public function withConfigFiles(string ...$fileNames): self
     {
         $this->configFiles = array_merge($this->configFiles, $fileNames);
+
         return $this;
     }
 
@@ -99,6 +100,7 @@ class ContainerBuilder
         $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveDefinitionTemplatesPass()]);
         $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
+
         return $container;
     }
 }

--- a/test/DependencyInjection/Fixture/config/xml/framework_bundle.xml
+++ b/test/DependencyInjection/Fixture/config/xml/framework_bundle.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xmlns:framework="http://symfony.com/schema/dic/symfony"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <framework:config>
+    </framework:config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/xml/stopwatch.xml
+++ b/test/DependencyInjection/Fixture/config/xml/stopwatch.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://getprooph.org/schemas/symfony-dic/prooph"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
+
+    <config>
+        <command_bus name="main_command_bus" message_factory="prooph_service_bus.message_factory">
+        </command_bus>
+    </config>
+</srv:container>

--- a/test/DependencyInjection/Fixture/config/yml/framework_bundle.yml
+++ b/test/DependencyInjection/Fixture/config/yml/framework_bundle.yml
@@ -1,0 +1,1 @@
+framework: ~

--- a/test/DependencyInjection/Fixture/config/yml/stopwatch.yml
+++ b/test/DependencyInjection/Fixture/config/yml/stopwatch.yml
@@ -1,0 +1,3 @@
+prooph_service_bus:
+  command_buses:
+    main_command_bus: ~

--- a/test/DependencyInjection/XmlServiceBusExtensionTest.php
+++ b/test/DependencyInjection/XmlServiceBusExtensionTest.php
@@ -12,14 +12,15 @@ declare(strict_types=1);
 namespace ProophTest\Bundle\ServiceBus\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class XmlServiceBusExtensionTest extends AbstractServiceBusExtensionTestCase
 {
-    protected function loadFromFile(ContainerBuilder $container, $file)
+    protected function buildContainer(): ContainerBuilder
     {
-        $loadXml = new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixture/config/xml'));
-        $loadXml->load($file.'.xml');
+        return ContainerBuilder::buildContainer(function (SymfonyContainerBuilder $container) {
+            return new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixture/config/xml'));
+        }, 'xml');
     }
 }

--- a/test/DependencyInjection/YamlServiceBusExtensionTest.php
+++ b/test/DependencyInjection/YamlServiceBusExtensionTest.php
@@ -12,14 +12,15 @@ declare(strict_types=1);
 namespace ProophTest\Bundle\ServiceBus\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class YamlServiceBusExtensionTest extends AbstractServiceBusExtensionTestCase
 {
-    protected function loadFromFile(ContainerBuilder $container, $file)
+    protected function buildContainer(): ContainerBuilder
     {
-        $loadYaml = new YamlFileLoader($container, new FileLocator(__DIR__.'/Fixture/config/yml'));
-        $loadYaml->load($file.'.yml');
+        return ContainerBuilder::buildContainer(function (SymfonyContainerBuilder $container) {
+            return new YamlFileLoader($container, new FileLocator(__DIR__.'/Fixture/config/yml'));
+        }, 'yml');
     }
 }

--- a/test/Plugin/StopwatchPluginTest.php
+++ b/test/Plugin/StopwatchPluginTest.php
@@ -63,6 +63,7 @@ class StopwatchPluginTest extends TestCase
 
         $commandBus = new CommandBus($eventEmitter);
         $commandBus->setBusName('we must set a name');
+
         return $commandBus;
     }
 }

--- a/test/Plugin/StopwatchPluginTest.php
+++ b/test/Plugin/StopwatchPluginTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProophTest\Bundle\ServiceBus\Plugin;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\Bundle\ServiceBus\CommandBus;
+use Prooph\Bundle\ServiceBus\Plugin\StopwatchPlugin;
+use Prooph\Bundle\ServiceBus\QueryBus;
+use Prooph\Common\Event\ActionEvent;
+use Prooph\Common\Event\ProophActionEventEmitter;
+use Prooph\Common\Messaging\Command;
+use Prooph\ServiceBus\MessageBus;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class StopwatchPluginTest extends TestCase
+{
+    /** @test */
+    public function it_times_the_the_runtime_of_events(): void
+    {
+        $commandBus = $this->createNamedNullCommandBus();
+
+        $stopWatch = new Stopwatch();
+        $plugin = new StopwatchPlugin($stopWatch);
+        $plugin->attachToMessageBus($commandBus);
+
+        $commandBus->dispatch($this->createCommand());
+
+        $this->assertCount(1, $stopWatch->getSectionEvents('__root__'));
+    }
+
+    /** @test */
+    public function it_cannot_be_attached_to_a_QueryBus(): void
+    {
+        $bus = $this->createQueryBus();
+
+        $stopWatch = new Stopwatch();
+        $plugin = new StopwatchPlugin($stopWatch);
+        $plugin->attachToMessageBus($bus);
+
+        $this->assertCount(0, $bus->plugins());
+    }
+
+    private function createCommand(): Command
+    {
+        return $this->createMock(Command::class);
+    }
+
+    private function createQueryBus(): QueryBus
+    {
+        return new QueryBus();
+    }
+
+    private function createNamedNullCommandBus(): CommandBus
+    {
+        $handler = function () {
+        };
+        $eventEmitter = new ProophActionEventEmitter();
+        $eventEmitter->attachListener(MessageBus::EVENT_DISPATCH, function (ActionEvent $event) use ($handler) {
+            $event->setParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLER, $handler);
+        }, MessageBus::PRIORITY_LOCATE_HANDLER + 10);
+
+        $commandBus = new CommandBus($eventEmitter);
+        $commandBus->setBusName('we must set a name');
+        return $commandBus;
+    }
+}


### PR DESCRIPTION
The stopwatch plugin is automatically enabled if the FrameworkBundle
is loaded and kernel.debug is active.

I'm not sure whether the compile pass is necessary.
Actually the `debug.stopwatch` service should be always available if `kernel.debug` is set, but there may be some edge cases …

reference https://github.com/prooph/service-bus-symfony-bundle/pull/23#issuecomment-333244432