### PR TITLE
[Query] Method could have 2 arguments, the command and a deferred

### DIFF
--- a/src/DependencyInjection/Compiler/RoutePass.php
+++ b/src/DependencyInjection/Compiler/RoutePass.php
@@ -91,7 +91,7 @@ class RoutePass implements CompilerPassInterface
         $methodsWithMessageParameter = array_filter(
             $handlerReflection->getMethods(ReflectionMethod::IS_PUBLIC),
             function (ReflectionMethod $method) {
-                return $method->getNumberOfRequiredParameters() === 1
+                return ($method->getNumberOfRequiredParameters() === 1 || $method->getNumberOfRequiredParameters() === 2)
                 && $method->getParameters()[0]->getClass()
                 && $method->getParameters()[0]->getClass()->getName() !== Message::class
                 && $method->getParameters()[0]->getClass()->implementsInterface(Message::class);


### PR DESCRIPTION
In a query finder, the __invoke method have a Deferred object as 2nd argument.