### PR TITLE
Small DI Fixes/Enhancements

### DIFF
--- a/src/DependencyInjection/Compiler/RoutePass.php
+++ b/src/DependencyInjection/Compiler/RoutePass.php
@@ -48,7 +48,7 @@ class RoutePass implements CompilerPassInterface
                 foreach ($handlers as $id => $args) {
                     // Safeguard to have only one tag per command / query
                     if ($type !== 'event' && count($args) > 1) {
-                        throw CompilerPassException::tagCountExceeded($id, $id, $bus);
+                        throw CompilerPassException::tagCountExceeded($type, $id, $bus);
                     }
                     foreach ($args as $eachArgs) {
                         if ((! isset($eachArgs['message_detection']) || $eachArgs['message_detection'] !== true) && ! isset($eachArgs['message'])) {

--- a/src/Exception/CompilerPassException.php
+++ b/src/Exception/CompilerPassException.php
@@ -8,21 +8,21 @@ class CompilerPassException extends RuntimeException
 {
     public static function messageTagMissing(string $serviceId): self
     {
-        throw new self(
-            sprintf('The "message" tag key is missing from tag. Either provide a "message" tag or enable "message_detection" for service "%s"',
-                $serviceId
-            )
-        );
+        return new self(sprintf(
+            'The "message" tag key is missing from tag. '
+                . 'Either provide a "message" tag or enable "message_detection" for service "%s"',
+            $serviceId
+        ));
     }
 
     public static function tagCountExceeded(string $type, string $serviceId, string $busName): self
     {
-        throw new self(
-            sprintf(
-                'More than 1 %s handler tagged on service "%s" with tag "%s". Only events can have multiple handlers',
-                $type, $serviceId, $busName
-            )
-        );
+        return new self(sprintf(
+            'More than 1 %s handler tagged on service "%s" with tag "%s". Only events can have multiple handlers',
+            $type,
+            $serviceId,
+            $busName
+        ));
     }
 
     public static function unknownHandlerClass(string $className, string $serviceId, string $busName): self

--- a/src/Exception/CompilerPassException.php
+++ b/src/Exception/CompilerPassException.php
@@ -24,4 +24,14 @@ class CompilerPassException extends RuntimeException
             )
         );
     }
+
+    public static function unknownHandlerClass(string $className, string $serviceId, string $busName): self
+    {
+        return new self(sprintf(
+            'Service %s has been tagged as %s handler, but its class %s does not exist',
+            $serviceId,
+            $busName,
+            $className
+        ));
+    }
 }

--- a/src/Exception/CompilerPassException.php
+++ b/src/Exception/CompilerPassException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Prooph\Bundle\ServiceBus\Exception;
 
-class CompilerPassException extends \RuntimeException
+class CompilerPassException extends RuntimeException
 {
     public static function messageTagMissing(string $serviceId): self
     {


### PR DESCRIPTION
 - `Prooph\Bundle\ServiceBus\Exception\CompilerPassException` now inherits from `Prooph\Bundle\ServiceBus\Exception\RuntimeException` instead of `\RuntimeException`.
 - Static factories of `Prooph\Bundle\ServiceBus\Exception\CompilerPassException` return exception objects instead of throwing them themself.
 - A message handler with message detection whose class does not exist has caused an undescriptive exception. I changed this to a more descriptive exception.