### PR TITLE
Refactor plugins and add phpstan tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; else ./vendor/bin/phpunit; fi
   - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run; fi
+  - ./vendor/bin/phpstan analyse -c phpstan.neon -l 7 src
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then php vendor/bin/coveralls -v; fi

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
     "react/promise": "^2.5",
     "friendsofphp/php-cs-fixer": " ~2.0",
     "prooph/php-cs-fixer-config": "^0.1.1",
-    "symfony/framework-bundle": "~3.3"
+    "symfony/framework-bundle": "~3.3",
+    "phpstan/phpstan": "^0.8.5"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
     "friendsofphp/php-cs-fixer": " ~2.0",
     "prooph/php-cs-fixer-config": "^0.1.1",
     "symfony/framework-bundle": "~3.3",
-    "phpstan/phpstan": "^0.8.5"
+    "phpstan/phpstan": "^0.8.5",
+    "symfony/expression-language": "^3.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/doc/routing.md
+++ b/doc/routing.md
@@ -43,6 +43,8 @@ The additional `message` attribute defines the message name (message class by de
 
 If your handler handles multiple messages, you need to add a tag for each one.
 
+> **Important**: Your handlers must be `public`.
+
 ### Automatic message detection
 
 If you are not afraid of a little bit magic

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    ignoreErrors:
+        # Only available in ArrayNodeDefinition which is given
+        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::fixXmlConfig\(\)\.#'
+        # NamedMessageBuses are always MessageBuses
+        - '#Call to an undefined method Prooph\\Bundle\\ServiceBus\\NamedMessageBus::attach\(\)\.#'

--- a/src/DependencyInjection/Compiler/RoutePass.php
+++ b/src/DependencyInjection/Compiler/RoutePass.php
@@ -92,18 +92,20 @@ class RoutePass implements CompilerPassInterface
         string $routeId,
         string $busType
     ): array {
-        $handlerReflection = $container->getReflectionClass($routeDefinition->getClass());
+        /* @var $routeClass string Help phpstan */
+        $routeClass = $routeDefinition->getClass();
+        $handlerReflection = $container->getReflectionClass($routeClass);
         if (! $handlerReflection) {
-            throw CompilerPassException::unknownHandlerClass($routeDefinition->getClass(), $routeId, $busType);
+            throw CompilerPassException::unknownHandlerClass($routeClass, $routeId, $busType);
         }
 
         $methodsWithMessageParameter = array_filter(
             $handlerReflection->getMethods(ReflectionMethod::IS_PUBLIC),
             function (ReflectionMethod $method) {
                 return ($method->getNumberOfRequiredParameters() === 1 || $method->getNumberOfRequiredParameters() === 2)
-                && $method->getParameters()[0]->getClass()
-                && $method->getParameters()[0]->getClass()->getName() !== Message::class
-                && $method->getParameters()[0]->getClass()->implementsInterface(Message::class);
+                    && $method->getParameters()[0]->getClass()
+                    && $method->getParameters()[0]->getClass()->getName() !== Message::class
+                    && $method->getParameters()[0]->getClass()->implementsInterface(Message::class);
             }
         );
 

--- a/src/DependencyInjection/ProophServiceBusExtension.php
+++ b/src/DependencyInjection/ProophServiceBusExtension.php
@@ -38,7 +38,7 @@ final class ProophServiceBusExtension extends Extension
 
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
-        return new Configuration($container->getParameter('kernel.debug'));
+        return new Configuration();
     }
 
     public function load(array $configs, ContainerBuilder $container)

--- a/src/Plugin/StopwatchPlugin.php
+++ b/src/Plugin/StopwatchPlugin.php
@@ -6,6 +6,7 @@ namespace Prooph\Bundle\ServiceBus\Plugin;
 
 use Prooph\Bundle\ServiceBus\NamedMessageBus;
 use Prooph\Common\Event\ActionEvent;
+use Prooph\Common\Messaging\Message;
 use Prooph\ServiceBus\MessageBus;
 use Prooph\ServiceBus\Plugin\AbstractPlugin;
 use Prooph\ServiceBus\QueryBus;
@@ -29,29 +30,39 @@ class StopwatchPlugin extends AbstractPlugin
             return;
         }
 
-        $resolveName = function (ActionEvent $event) {
-            if ($event->getTarget() instanceof NamedMessageBus) {
+        $resolveName = function (ActionEvent $event): string {
+            /* @var $message Message ensured below */
+            $message = $event->getParam(MessageBus::EVENT_PARAM_MESSAGE);
+            $messageBus = $event->getTarget();
+            if ($messageBus instanceof NamedMessageBus) {
                 return sprintf(
                     '%s:%s:%s',
-                    $event->getParam(MessageBus::EVENT_PARAM_MESSAGE)->messageType(),
-                    $event->getTarget()->busName(),
+                    $message->messageType(),
+                    $messageBus->busName(),
                     $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_NAME)
                 );
             }
 
             return sprintf(
-                    '%s:%s',
-                    $event->getParam(MessageBus::EVENT_PARAM_MESSAGE)->messageType(),
-                    $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_NAME)
-                );
+                '%s:%s',
+                $message->messageType(),
+                $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_NAME)
+            );
         };
 
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $event) use ($resolveName) {
-            $messageType = $event->getParam(MessageBus::EVENT_PARAM_MESSAGE)->messageType();
+            $message = $event->getParam(MessageBus::EVENT_PARAM_MESSAGE);
+            if (! $message instanceof Message) {
+                return;
+            }
+            $messageType = $message->messageType();
             $this->stopwatch->start($resolveName($event), $messageType === 'command' ? 'section' : $messageType);
         }, MessageBus::PRIORITY_INVOKE_HANDLER + 2000);
 
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_FINALIZE, function (ActionEvent $event) use ($resolveName) {
+            if (! $event->getParam(MessageBus::EVENT_PARAM_MESSAGE) instanceof Message) {
+                return;
+            }
             $this->stopwatch->stop($resolveName($event));
         }, -2000);
     }

--- a/src/Resources/views/Collector/debug_view.html.twig
+++ b/src/Resources/views/Collector/debug_view.html.twig
@@ -184,10 +184,12 @@
                     </div>
                     <h2>Messages</h2>
                     {% for i, message in messages %}
-                        <a name="{{ message['message-data']['uuid'] }}"></a>
+                        {% if message['message-data']['uuid'] is defined %}
+                            <a name="{{ message['message-data']['uuid'] }}"></a>
+                        {% endif %}
                         <table>
                             <thead>
-                            <th colspan="2">{{ message['message-name'] }}</th>
+                                <th colspan="2">{{ message['message-name'] }}</th>
                             </thead>
                             <tbody>
                             <tr>
@@ -196,11 +198,19 @@
                             </tr>
                             <tr>
                                 <td>Message created</td>
-                                <td>{{ message['message-data']['created_at']|date('Y-m-d H:i:s.u (P)') }}</td>
+                                {% if message['message-data']['created_at'] is defined %}
+                                    <td>{{ message['message-data']['created_at']|date('Y-m-d H:i:s.u (P)') }}</td>
+                                {% else %}
+                                    <td>This message is not supported by the default message converter. Please use another message converter.</td>
+                                {% endif %}
                             </tr>
                             <tr>
                                 <td>Uuid</td>
-                                <td>{{ message['message-data']['uuid'] }}</td>
+                                {% if message['message-data']['uuid'] is defined %}
+                                    <td>{{ message['message-data']['uuid'] }}</td>
+                                {% else %}
+                                    <td>This message is not supported by the default message converter. Please use another message converter.</td>
+                                {% endif %}
                             </tr>
                             {% if message['message-handler'] %}
                                 <tr>
@@ -225,7 +235,11 @@
                             {% endif %}
                             <tr>
                                 <td>Payload</td>
-                                <td>{{ dump(message['message-data']['payload']) }}</td>
+                                {% if message['message-data']['payload'] is defined %}
+                                    <td>{{ dump(message['message-data']['payload']) }}</td>
+                                {% else %}
+                                    <td>This message is not supported by the default message converter. Please use another message converter.</td>
+                                {% endif %}
                             </tr>
                             {% if message['message-data']['metadata'] is defined %}
                                 <tr>


### PR DESCRIPTION
The diff is hard to read, sorry :-/

The following things has been done:
 - Plugins based on the Message and the DomainMessage interface for
   messages while they can be objects or simple scalar values.
   Now they won't crash in this case anymore.
 - Document more clearly that handlers need to be public.
 - Add phpstan to detect some misspelled functions and type errors.

Fixes #42