### PR TITLE
Refactor DataCollector and PsrLoggerPlugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,10 @@
     "symfony/framework-bundle": "~3.3|^4.0",
     "phpstan/phpstan": "^0.9"
   },
+  "suggest": {
+      "symfony/stopwatch": "~3.3|^4.0",
+      "symfony/framework-bundle": "~3.3|^4.0"
+  },
   "minimum-stability": "dev",
   "prefer-stable": true,
   "extra": {

--- a/doc/configuration_reference.md
+++ b/doc/configuration_reference.md
@@ -10,6 +10,10 @@ prooph_service_bus:
         acme_command_bus:
             # Service ID of the message factory
             message_factory: 'prooph_service_bus.message_factory'
+            # Service ID of the message data converter
+            message_data_converter: 'prooph_service_bus.message_data_converter'
+            # Service ID of the message converter
+            message_converter: 'prooph_service_bus.message_converter'
             router:
                 # Service ID of the async message producer e.g. for Amazon AWS SQS
                 async_switch: 'my_async_message_producer'
@@ -29,6 +33,10 @@ prooph_service_bus:
         acme_event_bus:
             # Service ID of the message factory
             message_factory: 'prooph_service_bus.message_factory'
+            # Service ID of the message data converter
+            message_data_converter: 'prooph_service_bus.message_data_converter'
+            # Service ID of the message converter
+            message_converter: 'prooph_service_bus.message_converter'
             router:
                 # Service ID of the async message producer e.g. for Amazon AWS SQS
                 async_switch: 'my_async_message_producer'

--- a/doc/profiler.md
+++ b/doc/profiler.md
@@ -11,7 +11,7 @@ For most of them you will need access to the Symfony Profiler, so please ensure 
 The DataCollectorPlugin gathers data about the dispatched messages and shows them in an extra section within
 the Symfony Profiler.
 There is one profiler for the command- and one for the event-buses
-and both are automatically enabled if `kernel.debug` is `true`.
+and both are automatically enabled if `kernel.debug` is `true` and `symfony/stopwach` is installed.
 
 ![Example of a timeline with a command and an event](profiler_data_collector_sections.png)
 
@@ -28,7 +28,7 @@ You can find the logged messages either in the *Logs* section of the Symfony Pro
 ### StopwatchPlugin
 
 The StopwatchPlugin is automatically enabled if `kernel.debug` is `true`
-(which is the case e.g. in the `dev` environment).
+(which is the case e.g. in the `dev` environment) and `symfony/framework-bundle` is installed.
 It times the execution time of your command- and event-handlers.
 The collected data are shown within the *Performance* section of the Symfony Profiler.
 

--- a/doc/profiler.md
+++ b/doc/profiler.md
@@ -11,7 +11,7 @@ For most of them you will need access to the Symfony Profiler, so please ensure 
 The DataCollectorPlugin gathers data about the dispatched messages and shows them in an extra section within
 the Symfony Profiler.
 There is one profiler for the command- and one for the event-buses
-and both are automatically enabled if `kernel.debug` is `true` and `symfony/stopwach` is installed.
+and both are automatically enabled if `kernel.debug` is `true` and `symfony/stopwatch` is installed.
 
 ![Example of a timeline with a command and an event](profiler_data_collector_sections.png)
 

--- a/doc/profiler.md
+++ b/doc/profiler.md
@@ -4,7 +4,9 @@ The ProophServiceBusBundle provides several plugins that help you to inspect you
 For most of them you will need access to the Symfony Profiler, so please ensure that you have installed the
 [WebProfilerBundle](https://packagist.org/packages/symfony/web-profiler-bundle).
 
-## DataCollectorPlugin
+## Plugins
+
+### DataCollectorPlugin
 
 The DataCollectorPlugin gathers data about the dispatched messages and shows them in an extra section within
 the Symfony Profiler.
@@ -13,7 +15,7 @@ and both are automatically enabled if `kernel.debug` is `true`.
 
 ![Example of a timeline with a command and an event](profiler_data_collector_sections.png)
 
-## PsrLoggerPlugin
+### PsrLoggerPlugin
 
 The PsrLoggerPlugin fills your log with information about your dispatched messages.
 There will be one PsrLoggerPlugin automatically registered for each defined message bus.
@@ -23,7 +25,7 @@ You can find the logged messages either in the *Logs* section of the Symfony Pro
 
 ![Example of a timeline with a command and an event](profiler_logs.png)
 
-## StopwatchPlugin
+### StopwatchPlugin
 
 The StopwatchPlugin is automatically enabled if `kernel.debug` is `true`
 (which is the case e.g. in the `dev` environment).
@@ -33,3 +35,42 @@ The collected data are shown within the *Performance* section of the Symfony Pro
 For an example with a executed command and an executed event please have a look at the following image:
 
 ![Example of a timeline with a command and an event](profiler_timeline.png)
+
+## Message converter
+
+The `DataCollectorPlugin` and the `PsrLoggerPlugin` need to extract some data from your domain messages.
+By default they use the `Prooph\Common\Messaging\NoOpMessageConverter` to convert your messages into an array.
+This will work optimally for messages that extend `Prooph\Common\Messaging\DomainMessage`.
+Other messages will provide less data. 
+So if this is the case and you want more data shown, you can customize the conversion.
+
+### Possibility 1: Messages implement `Prooph\Common\Messaging\Message`
+
+If your messages implement `Prooph\Common\Messaging\Message` you can exchange the message converter.
+For an example you might want to have a look at the [`Prooph\Common\Messaging\NoOpMessageConverter`](https://github.com/prooph/common/blob/master/src/Messaging/NoOpMessageConverter.php).
+Implement your own message converter focused on your messages and then configure it for each bus as shown below:
+
+```yaml
+# app/config/config.yml or (flex) config/packages/prooph_service_bus.yaml
+prooph_service_bus:
+    command_buses:
+        acme_command_bus:
+            message_converter: '@my_message_converter'
+```
+ 
+
+### Possibility 2: Messages do not implement `Prooph\Common\Messaging\Message`
+
+In case your messages do not implement `Prooph\Common\Messaging\Message` exchanging the message converter want be useful,
+because the message converter only acts on instances of `Prooph\Common\Messaging\Message`.
+For this use case there is a special interface `Prooph\Bundle\ServiceBus\MessageContext\MessageDataConverter`
+that is less strict about the type of the message.
+You can implement your own message data converter and configure it for each bus as shown below:
+
+```yaml
+# app/config/config.yml or (flex) config/packages/prooph_service_bus.yaml
+prooph_service_bus:
+    command_buses:
+        acme_command_bus:
+            message_data_converter: '@my_message_data_converter'
+```

--- a/src/DependencyInjection/Compiler/RoutePass.php
+++ b/src/DependencyInjection/Compiler/RoutePass.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Prooph\Bundle\ServiceBus\DependencyInjection\Compiler;
 
 use Prooph\Bundle\ServiceBus\DependencyInjection\ProophServiceBusExtension;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -106,6 +106,28 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                         ->defaultValue('prooph_service_bus.message_factory')
                     ->end()
+                    ->scalarNode('message_data_converter')
+                        ->beforeNormalization()
+                            ->ifTrue(function ($v) {
+                                return strpos($v, '@') === 0;
+                            })
+                            ->then(function ($v) {
+                                return substr($v, 1);
+                            })
+                        ->end()
+                        ->defaultValue('prooph_service_bus.message_data_converter.' . $type)
+                    ->end()
+                    ->scalarNode('message_converter')
+                        ->beforeNormalization()
+                            ->ifTrue(function ($v) {
+                                return strpos($v, '@') === 0;
+                            })
+                            ->then(function ($v) {
+                                return substr($v, 1);
+                            })
+                        ->end()
+                        ->defaultValue('prooph_service_bus.message_converter')
+                    ->end()
                     ->arrayNode('plugins')
                         ->beforeNormalization()
                             // fix single node in XML

--- a/src/DependencyInjection/ProophServiceBusExtension.php
+++ b/src/DependencyInjection/ProophServiceBusExtension.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Prooph\Bundle\ServiceBus\DependencyInjection;
 
+use function class_exists;
 use Prooph\Bundle\ServiceBus\NamedMessageBus;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -19,6 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
  * Defines and load message bus instances.
@@ -80,7 +82,7 @@ final class ProophServiceBusExtension extends Extension
         $container->setParameter("prooph_service_bus.{$type}_buses", $serviceBuses);
 
         // Add DataCollector
-        if ($type !== 'query' && $container->getParameter('kernel.debug')) {
+        if ($type !== 'query' && $container->getParameter('kernel.debug') && class_exists(Stopwatch::class)) {
             $container
                 ->setDefinition(
                     sprintf('prooph_service_bus.plugin.symfony_data_collector.%s_bus', $type),
@@ -142,7 +144,7 @@ final class ProophServiceBusExtension extends Extension
             ->addArgument(new Reference($options['message_data_converter']));
 
         // Collecting data for each configured service bus
-        if ($type !== 'query' && $container->getParameter('kernel.debug')) {
+        if ($type !== 'query' && $container->getParameter('kernel.debug') && class_exists(Stopwatch::class)) {
             $container
                 ->setDefinition(
                     sprintf('%s.plugin.data_collector', $serviceBusId),

--- a/src/DependencyInjection/ProophServiceBusExtension.php
+++ b/src/DependencyInjection/ProophServiceBusExtension.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Prooph\Bundle\ServiceBus\DependencyInjection;
 
-use function class_exists;
 use Prooph\Bundle\ServiceBus\NamedMessageBus;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;

--- a/src/MessageContext/ContextFactory.php
+++ b/src/MessageContext/ContextFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prooph\Bundle\ServiceBus\MessageContext;
+
+use Prooph\Bundle\ServiceBus\NamedMessageBus;
+use Prooph\Common\Event\ActionEvent;
+use Prooph\ServiceBus\MessageBus;
+use ReflectionClass;
+
+/** @internal */
+class ContextFactory
+{
+    /** @var MessageDataConverter */
+    private $messageConverter;
+
+    public function __construct(MessageDataConverter $messageDataConverter)
+    {
+        $this->messageConverter = $messageDataConverter;
+    }
+
+    public function createFromActionEvent(ActionEvent $event): array
+    {
+        $messageBus = $event->getTarget();
+        $message = $event->getParam(MessageBus::EVENT_PARAM_MESSAGE);
+        $handler = $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLER);
+
+        $context = [
+            'message-data' => $this->messageConverter->convertMessageToArray($message),
+            'message-name' => $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_NAME),
+            'message-handled' => $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED),
+            'message-handler' => is_object($handler) ? get_class($handler) : (string) $handler,
+        ];
+
+        if ($messageBus instanceof NamedMessageBus) {
+            $context['bus-type'] = $messageBus->busType();
+            $context['bus-name'] = $messageBus->busName();
+            return $context;
+        }
+
+        $reflection = new ReflectionClass($messageBus);
+        $context['bus-type'] = $reflection->getShortName();
+        $context['bus-name'] = 'anonymous';
+        return $context;
+    }
+}

--- a/src/MessageContext/ContextFactory.php
+++ b/src/MessageContext/ContextFactory.php
@@ -36,12 +36,14 @@ class ContextFactory
         if ($messageBus instanceof NamedMessageBus) {
             $context['bus-type'] = $messageBus->busType();
             $context['bus-name'] = $messageBus->busName();
+
             return $context;
         }
 
         $reflection = new ReflectionClass($messageBus);
         $context['bus-type'] = $reflection->getShortName();
         $context['bus-name'] = 'anonymous';
+
         return $context;
     }
 }

--- a/src/MessageContext/DefaultMessageDataConverter.php
+++ b/src/MessageContext/DefaultMessageDataConverter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prooph\Bundle\ServiceBus\MessageContext;
+
+use Prooph\Common\Messaging\Message;
+use Prooph\Common\Messaging\MessageConverter;
+use Throwable;
+
+/** @internal */
+final class DefaultMessageDataConverter implements MessageDataConverter
+{
+    /** @var MessageConverter */
+    private $messageConverter;
+
+    public function __construct(MessageConverter $messageConverter)
+    {
+        $this->messageConverter = $messageConverter;
+    }
+
+    public function convertMessageToArray($message): array
+    {
+        if ($message instanceof Message) {
+            try {
+                return $this->messageConverter->convertToArray($message);
+            } catch (Throwable $exception) {
+                return [];
+            }
+        }
+
+        if (is_array($message)) {
+            return $message;
+        }
+
+        return [];
+    }
+}

--- a/src/MessageContext/MessageDataConverter.php
+++ b/src/MessageContext/MessageDataConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prooph\Bundle\ServiceBus\MessageContext;
+
+use Prooph\Common\Messaging\Message;
+use Prooph\Common\Messaging\MessageConverter;
+
+interface MessageDataConverter
+{
+    /**
+     * The MessageDataConverter converts a message into an array.
+     *
+     * It is less strict on parameter and result as the MessageConverter:
+     * The parameter MIGHT be an instance of \Prooph\Common\Messaging\Message.
+     * The result array SHOULD contain the following data structure:
+     *
+     * [
+     *   'message_name' => string,
+     *   'uuid' => string,
+     *   'payload' => array, //MUST only contain sub arrays and/or scalar types, objects, etc. are not allowed!
+     *   'metadata' => array, //MUST only contain key/value pairs with values being only scalar types!
+     *   'created_at' => \DateTimeInterface,
+     * ]
+     *
+     * @see Message
+     * @see MessageConverter
+     */
+    public function convertMessageToArray($message): array;
+}

--- a/src/Plugin/DataCollector.php
+++ b/src/Plugin/DataCollector.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prooph\Bundle\ServiceBus\Plugin;
+
+use Exception;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector as BaseDataCollector;
+
+class DataCollector extends BaseDataCollector
+{
+    /** @var string[] */
+    private $busNames = [];
+
+    /** @var ContainerInterface */
+    private $container;
+
+    public function __construct(ContainerInterface $container, string $busType)
+    {
+        $this->container = $container;
+        $this->data['bus_type'] = $busType;
+        $this->data['messages'] = [];
+        $this->data['duration'] = [];
+    }
+
+    public function collect(Request $request, Response $response, Exception $exception = null): void
+    {
+        foreach ($this->busNames as $busName) {
+            $this->data['config'][$busName] = $this->container->getParameter(
+                sprintf('prooph_service_bus.%s.configuration', $busName)
+            );
+        }
+    }
+
+    public function totalMessageCount(): int
+    {
+        return array_sum(array_map('count', $this->data['messages']));
+    }
+
+    public function totalBusCount(): int
+    {
+        return count($this->data['messages']);
+    }
+
+    public function messages(): array
+    {
+        return $this->data['messages'];
+    }
+
+    public function busDuration(string $busName): int
+    {
+        return $this->data['duration'][$busName];
+    }
+
+    public function callstack(string $busName): array
+    {
+        return $this->data['message_callstack'][$busName] ?? [];
+    }
+
+    public function config(string $busName): array
+    {
+        return $this->data['config'][$busName];
+    }
+
+    public function totalBusDuration(): int
+    {
+        return array_sum($this->data['duration']);
+    }
+
+    public function busType(): string
+    {
+        return $this->data['bus_type'];
+    }
+
+    public function getName(): string
+    {
+        return sprintf('prooph.%s_bus', $this->data['bus_type']);
+    }
+
+    public function addMessageBus(string $busName): void
+    {
+        $this->busNames[] = $busName;
+    }
+
+    public function addDuration(string $busName, int $duration, string $messageId, array $data): void
+    {
+        $this->data['duration'][$busName] = $duration;
+        $this->data['messages'][$busName][$messageId] = $data;
+    }
+
+    public function addCallstack(string $busName, array $log): void
+    {
+        $this->data['message_callstack'][$busName][] = $log;
+    }
+}

--- a/src/Plugin/DataCollector.php
+++ b/src/Plugin/DataCollector.php
@@ -35,6 +35,13 @@ class DataCollector extends BaseDataCollector
         }
     }
 
+    public function reset(): void
+    {
+        $this->data['messages'] = [];
+        $this->data['duration'] = [];
+        $this->busNames = [];
+    }
+
     public function totalMessageCount(): int
     {
         return array_sum(array_map('count', $this->data['messages']));

--- a/src/Plugin/DataCollector.php
+++ b/src/Plugin/DataCollector.php
@@ -24,6 +24,7 @@ class DataCollector extends BaseDataCollector
         $this->data['bus_type'] = $busType;
         $this->data['messages'] = [];
         $this->data['duration'] = [];
+        $this->data['message_callstack'] = [];
     }
 
     public function collect(Request $request, Response $response, Exception $exception = null): void
@@ -39,6 +40,7 @@ class DataCollector extends BaseDataCollector
     {
         $this->data['messages'] = [];
         $this->data['duration'] = [];
+        $this->data['message_callstack'] = [];
         $this->busNames = [];
     }
 
@@ -92,9 +94,9 @@ class DataCollector extends BaseDataCollector
         $this->busNames[] = $busName;
     }
 
-    public function addDuration(string $busName, int $duration, string $messageId, array $data): void
+    public function addMessage(string $busName, int $totalBusDuration, string $messageId, array $data): void
     {
-        $this->data['duration'][$busName] = $duration;
+        $this->data['duration'][$busName] = $totalBusDuration;
         $this->data['messages'][$busName][$messageId] = $data;
     }
 

--- a/src/Plugin/DataCollectorPlugin.php
+++ b/src/Plugin/DataCollectorPlugin.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Prooph\Bundle\ServiceBus\Plugin;
 
+use Prooph\Bundle\ServiceBus\Exception\RuntimeException;
 use Prooph\Bundle\ServiceBus\MessageContext\ContextFactory;
 use Prooph\Bundle\ServiceBus\NamedMessageBus;
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Messaging\Message;
-use Prooph\Bundle\ServiceBus\Exception\RuntimeException;
 use Prooph\ServiceBus\MessageBus;
 use Prooph\ServiceBus\Plugin\AbstractPlugin;
 use Prooph\ServiceBus\QueryBus;

--- a/src/Plugin/DataCollectorPlugin.php
+++ b/src/Plugin/DataCollectorPlugin.php
@@ -83,7 +83,7 @@ class DataCollectorPlugin extends AbstractPlugin
             $data = $this->contextFactory->createFromActionEvent($actionEvent);
             $data['duration'] = $this->stopwatch->stop($uuid)->getDuration();
 
-            $this->data->addDuration($busName, $this->stopwatch->lap($busName)->getDuration(), $uuid, $data);
+            $this->data->addMessage($busName, $this->stopwatch->lap($busName)->getDuration(), $uuid, $data);
         }, MessageBus::PRIORITY_INVOKE_HANDLER - 100);
 
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $actionEvent) {

--- a/src/Plugin/DataCollectorPlugin.php
+++ b/src/Plugin/DataCollectorPlugin.php
@@ -8,7 +8,7 @@ use Prooph\Bundle\ServiceBus\MessageContext\ContextFactory;
 use Prooph\Bundle\ServiceBus\NamedMessageBus;
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Messaging\Message;
-use Prooph\ServiceBus\Exception\RuntimeException;
+use Prooph\Bundle\ServiceBus\Exception\RuntimeException;
 use Prooph\ServiceBus\MessageBus;
 use Prooph\ServiceBus\Plugin\AbstractPlugin;
 use Prooph\ServiceBus\QueryBus;
@@ -47,11 +47,13 @@ class DataCollectorPlugin extends AbstractPlugin
         if (! $messageBus instanceof NamedMessageBus) {
             throw new RuntimeException(sprintf(
                 'To use the Symfony DataCollector, the Bus "%s" needs to implement "%s"',
-                $messageBus,
+                get_class($messageBus),
                 NamedMessageBus::class
             ));
         }
+
         $this->data->addMessageBus($messageBus->busName());
+
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $actionEvent) {
             /** @var NamedMessageBus $target Is ensured above */
             $target = $actionEvent->getTarget();

--- a/src/Plugin/DataCollectorPlugin.php
+++ b/src/Plugin/DataCollectorPlugin.php
@@ -4,32 +4,22 @@ declare(strict_types=1);
 
 namespace Prooph\Bundle\ServiceBus\Plugin;
 
-use Exception;
+use Prooph\Bundle\ServiceBus\MessageContext\ContextFactory;
 use Prooph\Bundle\ServiceBus\NamedMessageBus;
 use Prooph\Common\Event\ActionEvent;
-use Prooph\Common\Messaging\DomainMessage;
 use Prooph\Common\Messaging\Message;
 use Prooph\ServiceBus\Exception\RuntimeException;
 use Prooph\ServiceBus\MessageBus;
-use Prooph\ServiceBus\Plugin\Plugin;
+use Prooph\ServiceBus\Plugin\AbstractPlugin;
 use Prooph\ServiceBus\QueryBus;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\Stopwatch\Stopwatch;
 
-class DataCollectorPlugin extends DataCollector implements Plugin
+class DataCollectorPlugin extends AbstractPlugin
 {
     /**
-     * @var array
+     * @var DataCollector
      */
-    protected $listenerHandlers = [];
-
-    /**
-     * @var MessageBus[]&NamedMessageBus[]
-     */
-    private $buses = [];
+    private $data;
 
     /**
      * @var Stopwatch
@@ -37,74 +27,15 @@ class DataCollectorPlugin extends DataCollector implements Plugin
     private $stopwatch;
 
     /**
-     * @var ContainerInterface
+     * @var ContextFactory
      */
-    private $container;
+    private $contextFactory;
 
-    public function __construct(ContainerInterface $container, string $busType)
+    public function __construct(ContextFactory $contextFactory, DataCollector $data)
     {
         $this->stopwatch = new Stopwatch();
-        $this->container = $container;
-        $this->data['bus_type'] = $busType;
-        $this->data['messages'] = [];
-        $this->data['duration'] = [];
-    }
-
-    public function reset(): void
-    {
-        $this->data['messages'] = [];
-        $this->data['duration'] = [];
-    }
-
-    public function collect(Request $request, Response $response, Exception $exception = null)
-    {
-        foreach ($this->buses as $bus) {
-            $busName = $bus->busName();
-
-            $this->data['config'][$busName] = $this->container->getParameter(
-                sprintf('prooph_service_bus.%s.configuration', $busName)
-            );
-        }
-    }
-
-    public function getName(): string
-    {
-        return sprintf('prooph.%s_bus', $this->data['bus_type']);
-    }
-
-    public function totalMessageCount(): int
-    {
-        return array_sum(array_map('count', $this->data['messages']));
-    }
-
-    public function totalBusCount(): int
-    {
-        return count($this->data['messages']);
-    }
-
-    public function messages(): array
-    {
-        return $this->data['messages'];
-    }
-
-    public function busDuration(string $busName): int
-    {
-        return $this->data['duration'][$busName];
-    }
-
-    public function callstack(string $busName): array
-    {
-        return $this->data['message_callstack'][$busName] ?? [];
-    }
-
-    public function config(string $busName): array
-    {
-        return $this->data['config'][$busName];
-    }
-
-    public function totalBusDuration(): int
-    {
-        return array_sum($this->data['duration']);
+        $this->contextFactory = $contextFactory;
+        $this->data = $data;
     }
 
     public function attachToMessageBus(MessageBus $messageBus): void
@@ -113,7 +44,6 @@ class DataCollectorPlugin extends DataCollector implements Plugin
             return;
         }
 
-        $this->buses[] = $messageBus;
         if (! $messageBus instanceof NamedMessageBus) {
             throw new RuntimeException(sprintf(
                 'To use the Symfony DataCollector, the Bus "%s" needs to implement "%s"',
@@ -121,6 +51,7 @@ class DataCollectorPlugin extends DataCollector implements Plugin
                 NamedMessageBus::class
             ));
         }
+        $this->data->addMessageBus($messageBus->busName());
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $actionEvent) {
             /** @var NamedMessageBus $target Is ensured above */
             $target = $actionEvent->getTarget();
@@ -147,10 +78,10 @@ class DataCollectorPlugin extends DataCollector implements Plugin
                 return;
             }
             $uuid = (string) $message->uuid();
+            $data = $this->contextFactory->createFromActionEvent($actionEvent);
+            $data['duration'] = $this->stopwatch->stop($uuid)->getDuration();
 
-            $this->data['duration'][$busName] = $this->stopwatch->lap($busName)->getDuration();
-            $this->data['messages'][$busName][$uuid] = $this->createContextFromActionEvent($actionEvent);
-            $this->data['messages'][$busName][$uuid]['duration'] = $this->stopwatch->stop($uuid)->getDuration();
+            $this->data->addDuration($busName, $this->stopwatch->lap($busName)->getDuration(), $uuid, $data);
         }, MessageBus::PRIORITY_INVOKE_HANDLER - 100);
 
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $actionEvent) {
@@ -168,41 +99,11 @@ class DataCollectorPlugin extends DataCollector implements Plugin
                 'handler' => is_object($handler) ? get_class($handler) : (string) $handler,
             ];
             foreach ($actionEvent->getParam('event-listeners', []) as $handler) {
-                $this->data['message_callstack'][$messageBus->busName()][] = $log;
+                $this->data->addCallstack($messageBus->busName(), $log);
             }
             if ($handler !== null) {
-                $this->data['message_callstack'][$messageBus->busName()][] = $log;
+                $this->data->addCallstack($messageBus->busName(), $log);
             }
         }, MessageBus::PRIORITY_ROUTE - 50000);
-    }
-
-    public function detachFromMessageBus(MessageBus $messageBus): void
-    {
-        foreach ($this->listenerHandlers as $listenerHandler) {
-            $messageBus->detach($listenerHandler);
-        }
-
-        $this->listenerHandlers = [];
-    }
-
-    protected function createContextFromActionEvent(ActionEvent $event): array
-    {
-        /** @var NamedMessageBus $messageBus Is ensured above */
-        $messageBus = $event->getTarget();
-        $message = $event->getParam(MessageBus::EVENT_PARAM_MESSAGE);
-        $handler = $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLER);
-
-        return [
-            'bus-name' => $messageBus->busName(),
-            'message-data' => $message instanceof DomainMessage ? $message->toArray() : [],
-            'message-name' => $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_NAME),
-            'message-handled' => $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED),
-            'message-handler' => is_object($handler) ? get_class($handler) : (string) $handler,
-        ];
-    }
-
-    public function busType(): string
-    {
-        return $this->data['bus_type'];
     }
 }

--- a/src/Plugin/PsrLoggerPlugin.php
+++ b/src/Plugin/PsrLoggerPlugin.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Prooph\Bundle\ServiceBus\Plugin;
 
-use Prooph\Bundle\ServiceBus\NamedMessageBus;
+use Prooph\Bundle\ServiceBus\MessageContext\ContextFactory;
 use Prooph\Common\Event\ActionEvent;
-use Prooph\Common\Messaging\DomainMessage;
 use Prooph\ServiceBus\MessageBus;
 use Prooph\ServiceBus\Plugin\AbstractPlugin;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use ReflectionClass;
 
 class PsrLoggerPlugin extends AbstractPlugin
 {
@@ -20,15 +18,21 @@ class PsrLoggerPlugin extends AbstractPlugin
      */
     protected $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    /**
+     * @var ContextFactory
+     */
+    private $contextFactory;
+
+    public function __construct(ContextFactory $contextFactory, LoggerInterface $logger = null)
     {
+        $this->contextFactory = $contextFactory;
         $this->logger = $logger ?? new NullLogger();
     }
 
     public function attachToMessageBus(MessageBus $messageBus): void
     {
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $event) {
-            $context = $this->createContextFromActionEvent($event);
+            $context = $this->contextFactory->createFromActionEvent($event);
             $message = 'Dispatched {bus-type}:{message-name}';
             if ($context['message-handler'] !== null) {
                 $message = 'Dispatching {bus-type} {message-name} to handler {message-handler}';
@@ -37,7 +41,7 @@ class PsrLoggerPlugin extends AbstractPlugin
         }, MessageBus::PRIORITY_INVOKE_HANDLER + 2000);
 
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_FINALIZE, function (ActionEvent $event) {
-            $context = $this->createContextFromActionEvent($event);
+            $context = $this->contextFactory->createFromActionEvent($event);
             $message = 'Finished {bus-type}:{message-name}';
             if ($context['message-handler'] !== null) {
                 $message = 'Finished {bus-type}: "{message-name}" by handler {message-handler}';
@@ -46,48 +50,24 @@ class PsrLoggerPlugin extends AbstractPlugin
         }, -2000);
 
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $event) {
-            $context = $this->createContextFromActionEvent($event);
+            $context = $this->contextFactory->createFromActionEvent($event);
             $this->logger->debug('Initialized {bus-type} message {message-name}', $context);
         }, MessageBus::PRIORITY_INITIALIZE - 100);
 
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $event) {
-            $context = $this->createContextFromActionEvent($event);
+            $context = $this->contextFactory->createFromActionEvent($event);
             $this->logger->debug('Detect {bus-type} message name for {message-name}', $context);
         }, MessageBus::PRIORITY_DETECT_MESSAGE_NAME - 100);
 
         //Should be triggered because we did not provide a message-handler yet
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $event) {
-            $context = $this->createContextFromActionEvent($event);
+            $context = $this->contextFactory->createFromActionEvent($event);
             $this->logger->debug('Detect {bus-type} message route for {message-name}', $context);
         }, MessageBus::PRIORITY_ROUTE - 100);
 
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $event) {
-            $context = $this->createContextFromActionEvent($event);
+            $context = $this->contextFactory->createFromActionEvent($event);
             $this->logger->debug('Locate {bus-type} handler for {message-name}', $context);
         }, MessageBus::PRIORITY_LOCATE_HANDLER - 100);
-    }
-
-    protected function createContextFromActionEvent(ActionEvent $event): array
-    {
-        $context = [];
-        $messageBus = $event->getTarget();
-        if ($messageBus instanceof NamedMessageBus) {
-            $context['bus-type'] = $messageBus->busType();
-            $context['bus-name'] = $messageBus->busName();
-        } else {
-            $reflect = new ReflectionClass($messageBus);
-            $context['bus-type'] = $reflect->getShortName();
-            $context['bus-name'] = 'anonymous';
-        }
-
-        $message = $event->getParam(MessageBus::EVENT_PARAM_MESSAGE);
-        $messageHandler = $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLER);
-
-        return array_merge($context, [
-            'message-data' => $message instanceof DomainMessage ? $message->toArray() : [],
-            'message-name' => $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_NAME),
-            'message-handled' => $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED),
-            'message-handler' => is_object($messageHandler) ? get_class($messageHandler) : (string) $messageHandler,
-        ]);
     }
 }

--- a/src/Resources/config/service_bus.xml
+++ b/src/Resources/config/service_bus.xml
@@ -16,10 +16,15 @@
         </service>
 
         <service id="prooph_service_bus.plugin.psr_logger" class="Prooph\Bundle\ServiceBus\Plugin\PsrLoggerPlugin" abstract="true" public="false"/>
-        <service id="prooph_service_bus.plugin.data_collector" class="Prooph\Bundle\ServiceBus\Plugin\DataCollectorPlugin" abstract="true" public="false">
-            <argument type="service" id="service_container"/>
+        <service id="prooph_service_bus.plugin.data_collector" class="Prooph\Bundle\ServiceBus\Plugin\DataCollectorPlugin" abstract="true" public="false"/>
+        <service id="prooph_service_bus.plugin.symfony_data_collector" class="Prooph\Bundle\ServiceBus\Plugin\DataCollector" abstract="true" public="false">
+            <argument type="service" id="service_container" />
         </service>
 
         <service id="prooph_service_bus.async_switch_message_router" class="Prooph\ServiceBus\Plugin\Router\AsyncSwitchMessageRouter" />
+
+        <service id="prooph_service_bus.message_context_factory" class="Prooph\Bundle\ServiceBus\MessageContext\ContextFactory" abstract="true" public="false" />
+        <service id="prooph_service_bus.message_data_converter" class="Prooph\Bundle\ServiceBus\MessageContext\DefaultMessageDataConverter" abstract="true" public="false" />
+        <service id="prooph_service_bus.message_converter" class="Prooph\Common\Messaging\NoOpMessageConverter" public="false" />
     </services>
 </container>

--- a/test/MessageContext/ContextFactoryTest.php
+++ b/test/MessageContext/ContextFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProophTest\Bundle\ServiceBus\MessageContext;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\Bundle\ServiceBus\MessageContext\ContextFactory;
+use Prooph\Bundle\ServiceBus\MessageContext\MessageDataConverter;
+use Prooph\Bundle\ServiceBus\NamedMessageBus;
+use Prooph\Common\Event\DefaultActionEvent;
+use Prooph\Common\Messaging\Message;
+use Prooph\ServiceBus\MessageBus;
+use stdClass;
+
+/** @covers \Prooph\Bundle\ServiceBus\MessageContext\ContextFactory */
+class ContextFactoryTest extends TestCase
+{
+    /** @test */
+    public function it_creates_a_context_array_from_an_action_event(): void
+    {
+        $messageData = ['message_name' => 'my-acme-message'];
+
+        $messageConverter = $this->createMock(MessageDataConverter::class);
+        $messageBus = $this->createMock(NamedMessageBus::class);
+        $messageBus->expects($this->any())->method('busType')->willReturn('command');
+        $messageBus->expects($this->any())->method('busName')->willReturn('acme_command_bus');
+        $messageConverter->expects($this->any())->method('convertMessageToArray')->willReturn($messageData);
+
+        $actionEvent = new DefaultActionEvent('name-is-not-important', $messageBus, [
+            MessageBus::EVENT_PARAM_MESSAGE => $this->createMock(Message::class),
+            MessageBus::EVENT_PARAM_MESSAGE_NAME => 'my-acme-message',
+            MessageBus::EVENT_PARAM_MESSAGE_HANDLED => true,
+            MessageBus::EVENT_PARAM_MESSAGE_HANDLER => new stdClass(),
+        ]);
+
+        $result = (new ContextFactory($messageConverter))->createFromActionEvent($actionEvent);
+
+        $this->assertSame($result, [
+            'message-data' => $messageData,
+            'message-name' => 'my-acme-message',
+            'message-handled' => true,
+            'message-handler' => 'stdClass',
+            'bus-type' => 'command',
+            'bus-name' => 'acme_command_bus',
+        ]);
+    }
+
+    /** @test */
+    public function it_uses_anonymous_as_name_for_not_NamedMessageBuses()
+    {
+        $messageData = ['message_name' => 'my-acme-message'];
+
+        $messageConverter = $this->createMock(MessageDataConverter::class);
+        $messageBus = $this->createMock(MessageBus::class);
+        $messageConverter->expects($this->any())->method('convertMessageToArray')->willReturn($messageData);
+
+        $actionEvent = new DefaultActionEvent('name-is-not-important', $messageBus, [
+            MessageBus::EVENT_PARAM_MESSAGE => $this->createMock(Message::class),
+            MessageBus::EVENT_PARAM_MESSAGE_NAME => 'my-acme-message',
+            MessageBus::EVENT_PARAM_MESSAGE_HANDLED => true,
+            MessageBus::EVENT_PARAM_MESSAGE_HANDLER => new stdClass(),
+        ]);
+
+        $result = (new ContextFactory($messageConverter))->createFromActionEvent($actionEvent);
+
+        $this->assertSame($result['bus-name'], 'anonymous');
+    }
+}

--- a/test/MessageContext/ContextFactoryTest.php
+++ b/test/MessageContext/ContextFactoryTest.php
@@ -47,7 +47,7 @@ class ContextFactoryTest extends TestCase
     }
 
     /** @test */
-    public function it_uses_anonymous_as_name_for_not_NamedMessageBuses()
+    public function it_uses_anonymous_as_name_for_not_NamedMessageBuses(): void
     {
         $messageData = ['message_name' => 'my-acme-message'];
 

--- a/test/MessageContext/DefaultMessageDataConverterTest.php
+++ b/test/MessageContext/DefaultMessageDataConverterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProophTest\Bundle\ServiceBus\MessageContext;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Prooph\Bundle\ServiceBus\MessageContext\DefaultMessageDataConverter;
+use Prooph\Common\Messaging\Message;
+use Prooph\Common\Messaging\MessageConverter;
+
+/** @covers \Prooph\Bundle\ServiceBus\MessageContext\DefaultMessageDataConverter */
+class DefaultMessageDataConverterTest extends TestCase
+{
+    /** @test */
+    public function it_uses_as_MessageConverter_to_convert_Messages()
+    {
+        $message = $this->createMock(Message::class);
+        $messageConverter = $this->createMock(MessageConverter::class);
+        $messageConverter->expects($this->any())->method('convertToArray')->willReturn([
+            'message-name' => 'create-todo',
+        ]);
+
+        $result = (new DefaultMessageDataConverter($messageConverter))->convertMessageToArray($message);
+
+        $this->assertSame(['message-name' => 'create-todo'], $result);
+    }
+
+    /** @test */
+    public function it_converts_the_message_to_an_empty_array_if_the_MessageConverter_throws_an_exception()
+    {
+        $message = $this->createMock(Message::class);
+        $messageConverter = $this->createMock(MessageConverter::class);
+        $messageConverter->expects($this->any())->method('convertToArray')->willThrowException(new Exception());
+
+        $result = (new DefaultMessageDataConverter($messageConverter))->convertMessageToArray($message);
+
+        $this->assertSame([], $result);
+    }
+
+    public function it_simply_returns_the_message_if_the_message_is_an_array()
+    {
+        $message = ['name' => 'create-todo', 'text' => 'buy milk'];
+        $messageConverter = $this->createMock(MessageConverter::class);
+        $messageConverter->expects($this->never())->method('convertToArray');
+
+        $result = (new DefaultMessageDataConverter($messageConverter))->convertMessageToArray($message);
+
+        $this->assertSame($message, $result);
+    }
+
+    /** @test */
+    public function it_converts_scalars_to_an_empty_array()
+    {
+        $messageConverter = $this->createMock(MessageConverter::class);
+        $messageConverter->expects($this->never())->method('convertToArray');
+
+        $result = (new DefaultMessageDataConverter($messageConverter))->convertMessageToArray('create-todo');
+
+        $this->assertSame([], $result);
+    }
+}

--- a/test/MessageContext/DefaultMessageDataConverterTest.php
+++ b/test/MessageContext/DefaultMessageDataConverterTest.php
@@ -14,7 +14,7 @@ use Prooph\Common\Messaging\MessageConverter;
 class DefaultMessageDataConverterTest extends TestCase
 {
     /** @test */
-    public function it_uses_as_MessageConverter_to_convert_Messages()
+    public function it_uses_as_MessageConverter_to_convert_Messages(): void
     {
         $message = $this->createMock(Message::class);
         $messageConverter = $this->createMock(MessageConverter::class);
@@ -28,7 +28,7 @@ class DefaultMessageDataConverterTest extends TestCase
     }
 
     /** @test */
-    public function it_converts_the_message_to_an_empty_array_if_the_MessageConverter_throws_an_exception()
+    public function it_converts_the_message_to_an_empty_array_if_the_MessageConverter_throws_an_exception(): void
     {
         $message = $this->createMock(Message::class);
         $messageConverter = $this->createMock(MessageConverter::class);
@@ -39,7 +39,8 @@ class DefaultMessageDataConverterTest extends TestCase
         $this->assertSame([], $result);
     }
 
-    public function it_simply_returns_the_message_if_the_message_is_an_array()
+    /** @test */
+    public function it_simply_returns_the_message_if_the_message_is_an_array(): void
     {
         $message = ['name' => 'create-todo', 'text' => 'buy milk'];
         $messageConverter = $this->createMock(MessageConverter::class);
@@ -51,7 +52,7 @@ class DefaultMessageDataConverterTest extends TestCase
     }
 
     /** @test */
-    public function it_converts_scalars_to_an_empty_array()
+    public function it_converts_scalars_to_an_empty_array(): void
     {
         $messageConverter = $this->createMock(MessageConverter::class);
         $messageConverter->expects($this->never())->method('convertToArray');

--- a/test/Plugin/DataCollectorPluginTest.php
+++ b/test/Plugin/DataCollectorPluginTest.php
@@ -70,7 +70,7 @@ class DataCollectorPluginTest extends TestCase
         $messageBus = $this->createNamedCommandBusWithDummyHandler();
         $plugin->attachToMessageBus($messageBus);
 
-        $dataCollector->expects($this->never())->method('addDuration');
+        $dataCollector->expects($this->never())->method('addMessage');
         $dataCollector->expects($this->never())->method('addCallstack');
 
         $messageBus->dispatch('message as string');
@@ -84,7 +84,7 @@ class DataCollectorPluginTest extends TestCase
         $messageBus = $this->createNamedCommandBusWithDummyHandler();
         $plugin->attachToMessageBus($messageBus);
 
-        $dataCollector->expects($this->once())->method('addDuration');
+        $dataCollector->expects($this->once())->method('addMessage');
 
         $messageBus->dispatch(new AcmeRegisterUserCommand([]));
     }

--- a/test/Plugin/DataCollectorPluginTest.php
+++ b/test/Plugin/DataCollectorPluginTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProophTest\Bundle\ServiceBus\Plugin;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\Bundle\ServiceBus\CommandBus;
+use Prooph\Bundle\ServiceBus\Exception\RuntimeException;
+use Prooph\Bundle\ServiceBus\MessageContext\ContextFactory;
+use Prooph\Bundle\ServiceBus\Plugin\DataCollector;
+use Prooph\Bundle\ServiceBus\Plugin\DataCollectorPlugin;
+use Prooph\Common\Event\ActionEvent;
+use Prooph\ServiceBus\CommandBus as NotNamedCommandBus;
+use Prooph\ServiceBus\Exception\MessageDispatchException;
+use Prooph\ServiceBus\MessageBus;
+use Prooph\ServiceBus\QueryBus;
+use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\AcmeRegisterUserCommand;
+use Throwable;
+
+/**
+ * @covers \Prooph\Bundle\ServiceBus\Plugin\DataCollectorPlugin
+ */
+class DataCollectorPluginTest extends TestCase
+{
+    /** @test */
+    public function it_cannot_be_attached_to_a_QueryBus(): void
+    {
+        $plugin = new DataCollectorPlugin(
+            $this->createMock(ContextFactory::class),
+            $this->createMock(DataCollector::class)
+        );
+        $queryBus = $this->createMock(QueryBus::class);
+
+        $queryBus->expects($this->never())->method('attach');
+
+        $plugin->attachToMessageBus($queryBus);
+    }
+
+    /** @test */
+    public function it_cannot_be_attached_to_a_MessageBus_that_is_not_named(): void
+    {
+        $plugin = new DataCollectorPlugin(
+            $this->createMock(ContextFactory::class),
+            $this->createMock(DataCollector::class)
+        );
+        $messageBus = $this->createMock(NotNamedCommandBus::class);
+
+        $this->expectException(RuntimeException::class);
+
+        $plugin->attachToMessageBus($messageBus);
+    }
+
+    /** @test */
+    public function it_will_add_the_MessageBus_to_the_DataCollector(): void
+    {
+        $dataCollector = $this->createMock(DataCollector::class);
+        $plugin = new DataCollectorPlugin($this->createMock(ContextFactory::class), $dataCollector);
+        $messageBus = $this->createNamedCommandBus('default_command_bus');
+
+        $dataCollector->expects($this->once())->method('addMessageBus')->with('default_command_bus');
+
+        $plugin->attachToMessageBus($messageBus);
+    }
+
+    /** @test */
+    public function it_ignores_and_wont_fail_on_messages_that_do_not_implement_the_MessageInterface(): void
+    {
+        $dataCollector = $this->createMock(DataCollector::class);
+        $plugin = new DataCollectorPlugin($this->createMock(ContextFactory::class), $dataCollector);
+        $messageBus = $this->createNamedCommandBusWithDummyHandler();
+        $plugin->attachToMessageBus($messageBus);
+
+        $dataCollector->expects($this->never())->method('addDuration');
+        $dataCollector->expects($this->never())->method('addCallstack');
+
+        $messageBus->dispatch('message as string');
+    }
+
+    /** @test */
+    public function it_logs_the_duration_of_a_Message_execution(): void
+    {
+        $dataCollector = $this->createMock(DataCollector::class);
+        $plugin = new DataCollectorPlugin($this->createMock(ContextFactory::class), $dataCollector);
+        $messageBus = $this->createNamedCommandBusWithDummyHandler();
+        $plugin->attachToMessageBus($messageBus);
+
+        $dataCollector->expects($this->once())->method('addDuration');
+
+        $messageBus->dispatch(new AcmeRegisterUserCommand([]));
+    }
+
+    /** @test */
+    public function it_logs_the_callstack_of_a_Message_execution(): void
+    {
+        $dataCollector = $this->createMock(DataCollector::class);
+        $plugin = new DataCollectorPlugin($this->createMock(ContextFactory::class), $dataCollector);
+        $messageBus = $this->createNamedCommandBusWithDummyHandler();
+        $plugin->attachToMessageBus($messageBus);
+
+        $dataCollector->expects($this->once())->method('addCallstack');
+
+        $messageBus->dispatch(new AcmeRegisterUserCommand([]));
+    }
+
+    /** @test */
+    public function it_does_not_log_the_callstack_if_not_handler_is_available(): void
+    {
+        $dataCollector = $this->createMock(DataCollector::class);
+        $plugin = new DataCollectorPlugin($this->createMock(ContextFactory::class), $dataCollector);
+        $messageBus = $this->createNamedCommandBus();
+        $plugin->attachToMessageBus($messageBus);
+
+        $dataCollector->expects($this->never())->method('addCallstack');
+
+        try {
+            $messageBus->dispatch(new AcmeRegisterUserCommand([]));
+        } catch (MessageDispatchException $exception) {
+            // no handler available
+        }
+    }
+
+    private function createNamedCommandBus($name = 'default_command_bus'): CommandBus
+    {
+        $commandBus = new CommandBus();
+        $commandBus->setBusName($name);
+        return $commandBus;
+    }
+
+    private function createNamedCommandBusWithDummyHandler(): CommandBus
+    {
+        $commandBus = $this->createNamedCommandBus();
+        $commandBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $event) {
+            $event->setParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLER, function () {
+            });
+        }, MessageBus::PRIORITY_ROUTE);
+        return $commandBus;
+    }
+}

--- a/test/Plugin/DataCollectorPluginTest.php
+++ b/test/Plugin/DataCollectorPluginTest.php
@@ -16,7 +16,6 @@ use Prooph\ServiceBus\Exception\MessageDispatchException;
 use Prooph\ServiceBus\MessageBus;
 use Prooph\ServiceBus\QueryBus;
 use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\AcmeRegisterUserCommand;
-use Throwable;
 
 /**
  * @covers \Prooph\Bundle\ServiceBus\Plugin\DataCollectorPlugin
@@ -124,6 +123,7 @@ class DataCollectorPluginTest extends TestCase
     {
         $commandBus = new CommandBus();
         $commandBus->setBusName($name);
+
         return $commandBus;
     }
 
@@ -134,6 +134,7 @@ class DataCollectorPluginTest extends TestCase
             $event->setParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLER, function () {
             });
         }, MessageBus::PRIORITY_ROUTE);
+
         return $commandBus;
     }
 }

--- a/test/Plugin/DataCollectorTest.php
+++ b/test/Plugin/DataCollectorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace ProophTest\Bundle\ServiceBus\Plugin;
 
-use Prooph\Bundle\ServiceBus\Plugin\DataCollector;
 use PHPUnit\Framework\TestCase;
+use Prooph\Bundle\ServiceBus\Plugin\DataCollector;
 use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\AcmeRegisterUserCommand;
 use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\AcmeRegisterUserHandler;
 use Symfony\Component\DependencyInjection\Container;
@@ -118,7 +118,7 @@ class DataCollectorTest extends TestCase
         $log = [
             'id' => 'message-5',
             'message' => AcmeRegisterUserCommand::class,
-            'handler' => AcmeRegisterUserHandler::class
+            'handler' => AcmeRegisterUserHandler::class,
         ];
 
         $collector = new DataCollector(new Container(), 'command');
@@ -142,7 +142,7 @@ class DataCollectorTest extends TestCase
         $log = [
             'id' => 'message-5',
             'message' => AcmeRegisterUserCommand::class,
-            'handler' => AcmeRegisterUserHandler::class
+            'handler' => AcmeRegisterUserHandler::class,
         ];
         $collector = new DataCollector(new Container(), 'command');
         $collector->addCallstack('default_command_bus', $log);

--- a/test/Plugin/DataCollectorTest.php
+++ b/test/Plugin/DataCollectorTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProophTest\Bundle\ServiceBus\Plugin;
+
+use Prooph\Bundle\ServiceBus\Plugin\DataCollector;
+use PHPUnit\Framework\TestCase;
+use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\AcmeRegisterUserCommand;
+use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\AcmeRegisterUserHandler;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @covers \Prooph\Bundle\ServiceBus\Plugin\DataCollector
+ */
+class DataCollectorTest extends TestCase
+{
+    /** @test */
+    public function it_provides_its_bus_type(): void
+    {
+        $collector = new DataCollector(new Container(), 'command');
+        $this->assertSame('command', $collector->busType());
+    }
+
+    /** @test */
+    public function its_name_relates_to_the_bus_type_its_collecting_for(): void
+    {
+        $collector = new DataCollector(new Container(), 'command');
+        $this->assertSame('prooph.command_bus', $collector->getName());
+    }
+
+    /** @test */
+    public function it_collects_the_configuration_of_all_added_event_buses(): void
+    {
+        $config = ['config' => 'with values'];
+        $container = new Container();
+        $container->setParameter('prooph_service_bus.default_command_bus.configuration', $config);
+        $collector = new DataCollector($container, 'command');
+
+        $collector->addMessageBus('default_command_bus');
+
+        $collector->collect(new Request(), new Response());
+
+        $this->assertSame($config, $collector->config('default_command_bus'));
+    }
+
+    /** @test */
+    public function it_counts_the_buses_for_which_at_least_one_message_duration_has_been_recorded(): void
+    {
+        $collector = new DataCollector(new Container(), 'command');
+
+        $collector->addMessage('default_command_bus', 5, 'message-5', ['foo' => 'bar']);
+        $collector->addMessage('another_command_bus', 8, 'message-8', ['baz' => 'bar']);
+        $collector->addMessage('another_command_bus', 8, 'message-9', ['foo' => 'baz']);
+
+        $this->assertSame(2, $collector->totalBusCount());
+    }
+
+    /** @test */
+    public function it_counts_the_messages_that_has_been_recorded_for_all_buses(): void
+    {
+        $collector = new DataCollector(new Container(), 'command');
+
+        $collector->addMessage('default_command_bus', 5, 'message-5', ['foo' => 'bar']);
+        $collector->addMessage('another_command_bus', 8, 'message-8', ['baz' => 'bar']);
+        $collector->addMessage('another_command_bus', 8, 'message-9', ['foo' => 'baz']);
+
+        $this->assertSame(3, $collector->totalMessageCount());
+    }
+
+    /** @test */
+    public function it_computes_the_total_message_handling_duration_of_all_buses(): void
+    {
+        $collector = new DataCollector(new Container(), 'command');
+
+        $collector->addMessage('default_command_bus', 5, 'message-5', ['foo' => 'bar']);
+        $collector->addMessage('another_command_bus', 8, 'message-8', ['baz' => 'bar']);
+
+        $this->assertSame(13, $collector->totalBusDuration());
+    }
+
+    /** @test */
+    public function it_collects_the_message_handling_duration_for_a_single_bus(): void
+    {
+        $collector = new DataCollector(new Container(), 'command');
+
+        $collector->addMessage('default_command_bus', 5, 'message-5', ['foo' => 'bar']);
+        $collector->addMessage('default_command_bus', 8, 'message-8', ['baz' => 'bar']);
+
+        $this->assertSame(8, $collector->busDuration('default_command_bus'));
+    }
+
+    /** @test */
+    public function it_provides_the_collected_messages_grouped_by_their_bus(): void
+    {
+        $collector = new DataCollector(new Container(), 'command');
+
+        $collector->addMessage('default_command_bus', 5, 'message-5', ['foo' => 'bar']);
+        $collector->addMessage('another_command_bus', 8, 'message-8', ['baz' => 'bar']);
+        $collector->addMessage('another_command_bus', 8, 'message-9', ['foo' => 'baz']);
+
+        $this->assertSame([
+            'default_command_bus' => [
+                'message-5' => ['foo' => 'bar'],
+            ],
+            'another_command_bus' => [
+                'message-8' => ['baz' => 'bar'],
+                'message-9' => ['foo' => 'baz'],
+            ],
+        ], $collector->messages());
+    }
+
+    /** @test */
+    public function it_collects_callstacks_of_buses(): void
+    {
+        $log = [
+            'id' => 'message-5',
+            'message' => AcmeRegisterUserCommand::class,
+            'handler' => AcmeRegisterUserHandler::class
+        ];
+
+        $collector = new DataCollector(new Container(), 'command');
+
+        $collector->addCallstack('default_command_bus', $log);
+
+        $this->assertSame([$log], $collector->callstack('default_command_bus'));
+    }
+
+    /** @test */
+    public function it_provides_empty_callstacks_for_each_bus_that_has_no_callstack_added(): void
+    {
+        $collector = new DataCollector(new Container(), 'command');
+
+        $this->assertSame([], $collector->callstack('default_command_bus'));
+    }
+
+    /** @test */
+    public function it_can_be_reset(): void
+    {
+        $log = [
+            'id' => 'message-5',
+            'message' => AcmeRegisterUserCommand::class,
+            'handler' => AcmeRegisterUserHandler::class
+        ];
+        $collector = new DataCollector(new Container(), 'command');
+        $collector->addCallstack('default_command_bus', $log);
+        $collector->addMessage('default_command_bus', 8, 'message-9', ['foo' => 'baz']);
+
+        $collector->reset();
+
+        $this->assertSame(0, $collector->totalMessageCount());
+        $this->assertCount(0, $collector->callstack('default_command_bus'));
+    }
+}


### PR DESCRIPTION
 - DataCollector is extracted from the DataCollectorPlugin. This allows
   the DataCollectorPlugin to be configured independently for each bus
   while there is still exactly one DataCollector for each bus type.
 - Message context extraction has been moved to ContextFactory to avoid
   duplication.
 - Data conversion can be configured using the message_converter and the
   message_data_converter config for each bus.

Just a general concepts ATM, misses tests. I'm not sure whether the split between `message_converter` and `message_data_converter` is necessary, but this would allow to convert array messages.

See https://github.com/prooph/service-bus-symfony-bundle/pull/43#discussion_r148474228 for the origin of this pr.