### PR TITLE
Stopwatch duration are ints

### DIFF
--- a/src/Plugin/DataCollectorPlugin.php
+++ b/src/Plugin/DataCollectorPlugin.php
@@ -83,7 +83,8 @@ class DataCollectorPlugin extends AbstractPlugin
             $data = $this->contextFactory->createFromActionEvent($actionEvent);
             $data['duration'] = $this->stopwatch->stop($uuid)->getDuration();
 
-            $this->data->addMessage($busName, $this->stopwatch->lap($busName)->getDuration(), $uuid, $data);
+            // int casting is possible because the stopwatch is created with less precision
+            $this->data->addMessage($busName, (int) $this->stopwatch->lap($busName)->getDuration(), $uuid, $data);
         }, MessageBus::PRIORITY_INVOKE_HANDLER - 100);
 
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $actionEvent) {

--- a/src/Plugin/DataCollectorPlugin.php
+++ b/src/Plugin/DataCollectorPlugin.php
@@ -83,8 +83,9 @@ class DataCollectorPlugin extends AbstractPlugin
             $data = $this->contextFactory->createFromActionEvent($actionEvent);
             $data['duration'] = $this->stopwatch->stop($uuid)->getDuration();
 
-            // int casting is possible because the stopwatch is created with less precision
-            $this->data->addMessage($busName, (int) $this->stopwatch->lap($busName)->getDuration(), $uuid, $data);
+            /** @var int $duration Is ensured by creating the stopwatch with less precision */
+            $duration = $this->stopwatch->lap($busName)->getDuration();
+            $this->data->addMessage($busName, $duration, $uuid, $data);
         }, MessageBus::PRIORITY_INVOKE_HANDLER - 100);
 
         $this->listenerHandlers[] = $messageBus->attach(MessageBus::EVENT_DISPATCH, function (ActionEvent $actionEvent) {


### PR DESCRIPTION
Return type of `Stopwatch::lap()->getDuration()` has been widened to `int|float`. `float` will be returned if the Stopwatch is created with more precision. As we do not create the Stopwatch with more precision, we can rely on `int`.