### PR TITLE
Doc enhancements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
     "phpstan/phpstan": "^0.9"
   },
   "suggest": {
+      "react/promise": "^2.5 for using the query bus",
       "symfony/stopwatch": "~3.3|^4.0",
       "symfony/framework-bundle": "~3.3|^4.0"
   },

--- a/doc/configuration_reference.md
+++ b/doc/configuration_reference.md
@@ -68,3 +68,12 @@ prooph_service_bus:
             # Service IDs of plugins utilized by this query bus
             plugins: []
 ```
+
+## Tags
+
+ - `prooph_service_bus.<message-bus-name>.route_target` with either `message_detection: true`
+   or `message: <message-name>` to route messages.
+ - `prooph_service_bus.<message-bus-name>.plugin` to attach a plugin to a specific bus.
+ - `prooph_service_bus.command_bus.plugin` resp. `prooph_service_bus.query_bus.plugin`
+   resp. `prooph_service_bus.event_bus.plugin` to attach a plugin to every command bus resp. query bus resp. event bus.
+ - `prooph_service_bus.plugin` to attach a plugin to every bus.

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -12,6 +12,9 @@ composer require prooph/service-bus-symfony-bundle
 ```
 at the root of your Symfony project.
 
+> **Important**: If you want to use the query bus, please ensure to also install react/promise via
+> `composer require react/promise`
+
 ## Enable the Bundle
 
 To start using this bundle, register the bundle in your application's kernel class:

--- a/doc/routing.md
+++ b/doc/routing.md
@@ -101,3 +101,24 @@ This is necessary because events can be routed to multiple event handlers.
 
 Which way you choose to configure your routing is up to you.
 Each way has its benefits and drawbacks.
+
+## Async switch
+
+The async switch configuration allows to handle some messages asynchronously.
+For a general introduction into the `AsyncSwitchMessageRouter` please have a look at the [official documentation](http://docs.getprooph.org/service-bus/plugins.html#2-3-1-5).
+
+In short: The `AsyncSwitchMessageRouter` decorates the configured router and sends messages that 
+implement `Prooph\ServiceBus\Async\AsyncMessage` to a special message producer.
+Other messages will be handled by the decorated router.
+
+To use this switch with symfony, configure your own message producer (it must implement `Prooph\ServiceBus\Async\MessageProducer`)
+and pass its service id to the configuration:
+
+```yaml
+# app/config/config.yml or (flex) config/packages/prooph_service_bus.yaml
+prooph_service_bus:
+    command_buses:
+        acme_command_bus:
+            router:
+                async_switch: 'my_async_message_producer'
+```

--- a/doc/routing.md
+++ b/doc/routing.md
@@ -41,8 +41,6 @@ The additional `message` attribute defines the message name (message class by de
 
 If your handler handles multiple messages, you need to add a tag for each one.
 
-> **Important**: Your handlers must be `public`.
-
 ### Automatic message detection
 
 If you are not afraid of a little bit magic


### PR DESCRIPTION
- List all tags in the configuration reference
- Explain the async switch (#30)
- Remove notice about public handlers (https://github.com/prooph/service-bus-symfony-bundle/releases/tag/v0.7.0)
- Install react/promise to use the query bus (#63)