### PR TITLE
Detect message handlers with popo-messages

### DIFF
--- a/doc/routing.md
+++ b/doc/routing.md
@@ -63,7 +63,7 @@ But don't worry about performance because this will happen on compiling.
 
 > **Important:** Automatic message detection can only detect handlers where either
 > the message implements `Prooph\Common\Messaging\HasMessageName` or the
-> name of the message is `__invoke`. In both cases the object must be a non abstract class.
+> name of the method is `__invoke`. In both cases the object must be a non abstract class.
 
 > **Hint:** If you rely on automatic message detection and your handler handles multiple messages of the same message bus,
 > you need to tag the handler just once.

--- a/doc/routing.md
+++ b/doc/routing.md
@@ -61,6 +61,10 @@ The bundle will try to detect the message itself
 by analyzing the methods of the handler and creating instances of the message objects.
 But don't worry about performance because this will happen on compiling.
 
+> **Important:** Automatic message detection can only detect handlers where either
+> the message implements `Prooph\Common\Messaging\HasMessageName` or the
+> name of the message is `__invoke`. In both cases the object must be a non abstract class.
+
 > **Hint:** If you rely on automatic message detection and your handler handles multiple messages of the same message bus,
 > you need to tag the handler just once.
 

--- a/src/DependencyInjection/Compiler/RoutePass.php
+++ b/src/DependencyInjection/Compiler/RoutePass.php
@@ -18,6 +18,9 @@ class RoutePass implements CompilerPassInterface
 {
     private static function detectMessageName(ReflectionClass $messageReflection): ?string
     {
+        if (! $messageReflection->implementsInterface(HasMessageName::class)) {
+            return $messageReflection->getName();
+        }
         $instance = $messageReflection->newInstanceWithoutConstructor(); /* @var $instance HasMessageName */
         if ($messageReflection->hasMethod('init')) {
             $init = $messageReflection->getMethod('init');
@@ -111,7 +114,8 @@ class RoutePass implements CompilerPassInterface
             function (ReflectionMethod $method) {
                 return ($method->getNumberOfRequiredParameters() === 1 || $method->getNumberOfRequiredParameters() === 2)
                     && $method->getParameters()[0]->getClass()
-                    && $method->getParameters()[0]->getClass()->implementsInterface(HasMessageName::class)
+                    && ($method->getParameters()[0]->getClass()->implementsInterface(HasMessageName::class)
+                        || $method->getName() === '__invoke')
                     && ! ($method->getParameters()[0]->getClass()->isInterface()
                         || $method->getParameters()[0]->getClass()->isAbstract()
                         || $method->getParameters()[0]->getClass()->isTrait());

--- a/test/DependencyInjection/AbstractServiceBusExtensionTestCase.php
+++ b/test/DependencyInjection/AbstractServiceBusExtensionTestCase.php
@@ -31,8 +31,10 @@ use ProophTest\Bundle\ServiceBus\DependencyInjection\ContainerBuilder as ProophC
 use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\AcmeRegisterUserCommand;
 use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\AcmeRegisterUserHandler;
 use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\AcmeUserWasRegisteredEvent;
+use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\CommandHandlerForPopoCommand;
 use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\CommandWithPrivateConstructor;
 use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\MockPlugin;
+use ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\PopoCommand;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
@@ -355,6 +357,25 @@ abstract class AbstractServiceBusExtensionTestCase extends TestCase
 
         // Test whether message detection works on commands with a private constructor
         $commandBus->dispatch(CommandWithPrivateConstructor::create());
+    }
+
+    /**
+     * @test
+     */
+    public function it_supports_automatic_message_detection_with_popo_messages_and_invokable_handlers()
+    {
+        $container = $this->loadContainer('command_bus_with_tags', new PluginsPass(), new RoutePass());
+
+        /* @var $commandBus CommandBus */
+        $commandBus = $container->get('prooph_service_bus.main_command_bus');
+
+        /** @var CommandHandlerForPopoCommand $mockHandler */
+        $mockHandler = $container->get(CommandHandlerForPopoCommand::class);
+        $command = new PopoCommand();
+
+        $commandBus->dispatch($command);
+
+        self::assertSame($command, $mockHandler->lastCommand);
     }
 
     /**

--- a/test/DependencyInjection/Fixture/Model/CommandHandlerForPopoCommand.php
+++ b/test/DependencyInjection/Fixture/Model/CommandHandlerForPopoCommand.php
@@ -13,4 +13,13 @@ final class CommandHandlerForPopoCommand
     {
         $this->lastCommand = $command;
     }
+
+    /**
+     * Do not take notice of this method.
+     * It is necessary to run the tests against prooph/service-bus:6.0.0
+     * @see https://github.com/prooph/service-bus/pull/159
+     */
+    public function handle(): void
+    {
+    }
 }

--- a/test/DependencyInjection/Fixture/Model/CommandHandlerForPopoCommand.php
+++ b/test/DependencyInjection/Fixture/Model/CommandHandlerForPopoCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model;
+
+final class CommandHandlerForPopoCommand
+{
+    /** @var PopoCommand|null */
+    public $lastCommand;
+
+    public function __invoke(PopoCommand $command)
+    {
+        $this->lastCommand = $command;
+    }
+}

--- a/test/DependencyInjection/Fixture/Model/PopoCommand.php
+++ b/test/DependencyInjection/Fixture/Model/PopoCommand.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model;
+
+final class PopoCommand
+{
+}

--- a/test/DependencyInjection/Fixture/config/xml/command_bus_with_tags.xml
+++ b/test/DependencyInjection/Fixture/config/xml/command_bus_with_tags.xml
@@ -22,5 +22,8 @@
         <srv:service id="ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\CommandHandlerForCommandWithPrivateConstructor">
             <srv:tag name="prooph_service_bus.main_command_bus.route_target" message_detection="true" />
         </srv:service>
+        <srv:service id="ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\CommandHandlerForPopoCommand" public="true">
+            <srv:tag name="prooph_service_bus.main_command_bus.route_target" message_detection="true" />
+        </srv:service>
     </srv:services>
 </srv:container>

--- a/test/DependencyInjection/Fixture/config/yml/command_bus_with_tags.yml
+++ b/test/DependencyInjection/Fixture/config/yml/command_bus_with_tags.yml
@@ -19,3 +19,8 @@ services:
   ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\CommandHandlerForCommandWithPrivateConstructor:
     tags:
       - { name: 'prooph_service_bus.main_command_bus.route_target', message_detection: true }
+
+  ProophTest\Bundle\ServiceBus\DependencyInjection\Fixture\Model\CommandHandlerForPopoCommand:
+    public: true
+    tags:
+      - { name: 'prooph_service_bus.main_command_bus.route_target', message_detection: true }


### PR DESCRIPTION
Auto-detection will be possible with handlers that have a `__invoke` method.

See https://github.com/prooph/service-bus-symfony-bundle/issues/63#issuecomment-368413817

Fixes #72 