### PR TITLE
Fixing the test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,13 +66,13 @@
   "require-dev": {
     "phpunit/phpunit": "^6.0",
     "prooph/bookdown-template": "^0.2.3",
-    "satooshi/php-coveralls": "^1.0",
     "phpspec/prophecy": "^1.7",
     "react/promise": "^2.5",
     "friendsofphp/php-cs-fixer": "~2.0",
     "prooph/php-cs-fixer-config": "^0.2",
     "symfony/framework-bundle": "~3.3|^4.0",
-    "phpstan/phpstan": "^0.9"
+    "phpstan/phpstan": "^0.9",
+    "php-coveralls/php-coveralls": "^2.1"
   },
   "suggest": {
       "react/promise": "^2.5 for using the query bus",

--- a/src/DependencyInjection/Compiler/PluginsPass.php
+++ b/src/DependencyInjection/Compiler/PluginsPass.php
@@ -29,10 +29,10 @@ class PluginsPass implements CompilerPassInterface
 
             foreach ($buses as $name => $bus) {
                 $globalPlugins = $container->findTaggedServiceIds('prooph_service_bus.plugin');
-                $typePlugins = $container->findTaggedServiceIds(sprintf('prooph_service_bus.%s.plugin', $type . '_bus'));
-                $localPlugins = $container->findTaggedServiceIds(sprintf('prooph_service_bus.%s.plugin', $name));
+                $typePlugins = $container->findTaggedServiceIds(\sprintf('prooph_service_bus.%s.plugin', $type . '_bus'));
+                $localPlugins = $container->findTaggedServiceIds(\sprintf('prooph_service_bus.%s.plugin', $name));
 
-                $plugins = array_merge(array_keys($globalPlugins), array_keys($typePlugins), array_keys($localPlugins));
+                $plugins = \array_merge(\array_keys($globalPlugins), \array_keys($typePlugins), \array_keys($localPlugins));
 
                 $busDefinition = $container->getDefinition($bus);
 

--- a/src/DependencyInjection/Compiler/RoutePass.php
+++ b/src/DependencyInjection/Compiler/RoutePass.php
@@ -41,22 +41,22 @@ class RoutePass implements CompilerPassInterface
             $buses = $container->getParameter('prooph_service_bus.' . $type . '_buses');
 
             foreach ($buses as $name => $bus) {
-                $routerServiceId = sprintf('prooph_service_bus.%s.decorated_router', $name);
+                $routerServiceId = \sprintf('prooph_service_bus.%s.decorated_router', $name);
                 if (! $container->has($routerServiceId)) {
-                    $routerServiceId = sprintf('prooph_service_bus.%s.router', $name);
+                    $routerServiceId = \sprintf('prooph_service_bus.%s.router', $name);
                 }
                 $router = $container->findDefinition($routerServiceId);
 
                 $routerArguments = $router->getArguments();
-                $serviceLocator = $container->findDefinition(sprintf('%s.plugin.service_locator.locator', $name));
+                $serviceLocator = $container->findDefinition(\sprintf('%s.plugin.service_locator.locator', $name));
                 $serviceLocatorServices = $serviceLocator->getArgument(0);
 
-                $handlers = $container->findTaggedServiceIds(sprintf('prooph_service_bus.%s.route_target', $name));
+                $handlers = $container->findTaggedServiceIds(\sprintf('prooph_service_bus.%s.route_target', $name));
 
                 foreach ($handlers as $id => $args) {
                     $serviceLocatorServices[$id] = new Reference($id);
                     // Safeguard to have only one tag per command / query
-                    if ($type !== 'event' && count($args) > 1) {
+                    if ($type !== 'event' && \count($args) > 1) {
                         throw CompilerPassException::tagCountExceeded($type, $id, $bus);
                     }
                     foreach ($args as $eachArgs) {
@@ -69,15 +69,15 @@ class RoutePass implements CompilerPassInterface
                             : $this->recognizeMessageNames($container, $container->getDefinition($id), $id, $type);
 
                         if ($type === 'event') {
-                            $routerArguments[0] = array_merge_recursive(
+                            $routerArguments[0] = \array_merge_recursive(
                                 $routerArguments[0],
-                                array_combine($messageNames, array_fill(0, count($messageNames), [$id]))
+                                \array_combine($messageNames, \array_fill(0, \count($messageNames), [$id]))
                             );
-                            $routerArguments[0] = array_map('array_unique', $routerArguments[0]);
+                            $routerArguments[0] = \array_map('array_unique', $routerArguments[0]);
                         } else {
-                            $routerArguments[0] = array_merge(
+                            $routerArguments[0] = \array_merge(
                                 $routerArguments[0],
-                                array_combine($messageNames, array_fill(0, count($messageNames), $id))
+                                \array_combine($messageNames, \array_fill(0, \count($messageNames), $id))
                             );
                         }
                     }
@@ -86,10 +86,10 @@ class RoutePass implements CompilerPassInterface
                 $serviceLocator->setArgument(0, $serviceLocatorServices);
 
                 // Update route configuration parameter
-                $configId = sprintf('prooph_service_bus.%s.configuration', $name);
+                $configId = \sprintf('prooph_service_bus.%s.configuration', $name);
 
-                $routes = is_array($routerArguments[0]) ? $routerArguments[0] : [];
-                $config = array_replace($container->getParameter($configId), ['router' => ['routes' => $routes]]);
+                $routes = \is_array($routerArguments[0]) ? $routerArguments[0] : [];
+                $config = \array_replace($container->getParameter($configId), ['router' => ['routes' => $routes]]);
 
                 $container->setParameter($configId, $config);
             }
@@ -109,7 +109,7 @@ class RoutePass implements CompilerPassInterface
             throw CompilerPassException::unknownHandlerClass($routeClass, $routeId, $busType);
         }
 
-        $methodsWithMessageParameter = array_filter(
+        $methodsWithMessageParameter = \array_filter(
             $handlerReflection->getMethods(ReflectionMethod::IS_PUBLIC),
             function (ReflectionMethod $method) {
                 return ($method->getNumberOfRequiredParameters() === 1 || $method->getNumberOfRequiredParameters() === 2)
@@ -122,7 +122,7 @@ class RoutePass implements CompilerPassInterface
             }
         );
 
-        return array_unique(array_map(function (ReflectionMethod $method) {
+        return \array_unique(\array_map(function (ReflectionMethod $method) {
             return self::detectMessageName($method->getParameters()[0]->getClass());
         }, $methodsWithMessageParameter));
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -66,10 +66,10 @@ final class Configuration implements ConfigurationInterface
                 ->prototype('scalar')
                     ->beforeNormalization()
                         ->ifTrue(function ($v) {
-                            return is_string($v) && strpos($v, '@') === 0;
+                            return \is_string($v) && \strpos($v, '@') === 0;
                         })
                         ->then(function ($v) {
-                            return substr($v, 1);
+                            return \substr($v, 1);
                         })
                     ->end()
                 ->end();
@@ -77,10 +77,10 @@ final class Configuration implements ConfigurationInterface
             $handlerNode
                 ->beforeNormalization()
                     ->ifTrue(function ($v) {
-                        return is_string($v) && strpos($v, '@') === 0;
+                        return \is_string($v) && \strpos($v, '@') === 0;
                     })
                     ->then(function ($v) {
-                        return substr($v, 1);
+                        return \substr($v, 1);
                     })
                 ->end();
         }
@@ -98,10 +98,10 @@ final class Configuration implements ConfigurationInterface
                     ->scalarNode('message_factory')
                         ->beforeNormalization()
                             ->ifTrue(function ($v) {
-                                return is_string($v) && strpos($v, '@') === 0;
+                                return \is_string($v) && \strpos($v, '@') === 0;
                             })
                             ->then(function ($v) {
-                                return substr($v, 1);
+                                return \substr($v, 1);
                             })
                         ->end()
                         ->defaultValue('prooph_service_bus.message_factory')
@@ -109,10 +109,10 @@ final class Configuration implements ConfigurationInterface
                     ->scalarNode('message_data_converter')
                         ->beforeNormalization()
                             ->ifTrue(function ($v) {
-                                return is_string($v) && strpos($v, '@') === 0;
+                                return \is_string($v) && \strpos($v, '@') === 0;
                             })
                             ->then(function ($v) {
-                                return substr($v, 1);
+                                return \substr($v, 1);
                             })
                         ->end()
                         ->defaultValue('prooph_service_bus.message_data_converter.' . $type)
@@ -120,10 +120,10 @@ final class Configuration implements ConfigurationInterface
                     ->scalarNode('message_converter')
                         ->beforeNormalization()
                             ->ifTrue(function ($v) {
-                                return is_string($v) && strpos($v, '@') === 0;
+                                return \is_string($v) && \strpos($v, '@') === 0;
                             })
                             ->then(function ($v) {
-                                return substr($v, 1);
+                                return \substr($v, 1);
                             })
                         ->end()
                         ->defaultValue('prooph_service_bus.message_converter')
@@ -138,10 +138,10 @@ final class Configuration implements ConfigurationInterface
                         ->prototype('scalar')
                             ->beforeNormalization()
                                 ->ifTrue(function ($v) {
-                                    return is_string($v) && strpos($v, '@') === 0;
+                                    return \is_string($v) && \strpos($v, '@') === 0;
                                 })
                                 ->then(function ($v) {
-                                    return substr($v, 1);
+                                    return \substr($v, 1);
                                 })
                             ->end()
                         ->end()
@@ -153,10 +153,10 @@ final class Configuration implements ConfigurationInterface
                             ->scalarNode('type')
                                 ->beforeNormalization()
                                     ->ifTrue(function ($v) {
-                                        return is_string($v) && strpos($v, '@') === 0;
+                                        return \is_string($v) && \strpos($v, '@') === 0;
                                     })
                                     ->then(function ($v) {
-                                        return substr($v, 1);
+                                        return \substr($v, 1);
                                     })
                                 ->end()
                                 ->defaultValue('prooph_service_bus.' . $type . '_bus_router')
@@ -164,10 +164,10 @@ final class Configuration implements ConfigurationInterface
                             ->scalarNode('async_switch')
                                 ->beforeNormalization()
                                     ->ifTrue(function ($v) {
-                                        return is_string($v) && strpos($v, '@') === 0;
+                                        return \is_string($v) && \strpos($v, '@') === 0;
                                     })
                                     ->then(function ($v) {
-                                        return substr($v, 1);
+                                        return \substr($v, 1);
                                     })
                                 ->end()
                             ->end()

--- a/src/DependencyInjection/ProophServiceBusExtension.php
+++ b/src/DependencyInjection/ProophServiceBusExtension.php
@@ -76,21 +76,21 @@ final class ProophServiceBusExtension extends Extension
         $loader->load($type . '_bus.xml');
 
         $serviceBuses = [];
-        foreach (array_keys($config) as $name) {
+        foreach (\array_keys($config) as $name) {
             $serviceBuses[$name] = 'prooph_service_bus.' . $name;
         }
         $container->setParameter("prooph_service_bus.{$type}_buses", $serviceBuses);
 
         // Add DataCollector
-        if ($type !== 'query' && $container->getParameter('kernel.debug') && class_exists(Stopwatch::class)) {
+        if ($type !== 'query' && $container->getParameter('kernel.debug') && \class_exists(Stopwatch::class)) {
             $container
                 ->setDefinition(
-                    sprintf('prooph_service_bus.plugin.symfony_data_collector.%s_bus', $type),
+                    \sprintf('prooph_service_bus.plugin.symfony_data_collector.%s_bus', $type),
                     new ChildDefinition('prooph_service_bus.plugin.symfony_data_collector')
                 )
                 ->addArgument($type)
                 ->addTag('data_collector', [
-                    'id' => sprintf('prooph.%s_bus', $type),
+                    'id' => \sprintf('prooph.%s_bus', $type),
                     'template' => '@ProophServiceBus/Collector/debug_view.html.twig',
                 ]);
         }
@@ -120,7 +120,7 @@ final class ProophServiceBusExtension extends Extension
             new ChildDefinition('prooph_service_bus.' . $type . '_bus')
         );
         $serviceBusDefinition->setPublic(true);
-        if (in_array(NamedMessageBus::class, class_implements($container->getDefinition('prooph_service_bus.'.$type.'_bus')->getClass()))) {
+        if (\in_array(NamedMessageBus::class, \class_implements($container->getDefinition('prooph_service_bus.'.$type.'_bus')->getClass()))) {
             $serviceBusDefinition->addMethodCall('setBusName', [$name]);
             $serviceBusDefinition->addMethodCall('setBusType', [$type]);
         }
@@ -138,35 +138,35 @@ final class ProophServiceBusExtension extends Extension
             )
             ->addArgument(new Reference($options['message_converter']));
 
-        $contextFactoryId = sprintf('prooph_service_bus.message_context_factory.%s', $serviceBusId);
+        $contextFactoryId = \sprintf('prooph_service_bus.message_context_factory.%s', $serviceBusId);
         $container
             ->setDefinition($contextFactoryId, new ChildDefinition('prooph_service_bus.message_context_factory'))
             ->addArgument(new Reference($options['message_data_converter']));
 
         // Collecting data for each configured service bus
-        if ($type !== 'query' && $container->getParameter('kernel.debug') && class_exists(Stopwatch::class)) {
+        if ($type !== 'query' && $container->getParameter('kernel.debug') && \class_exists(Stopwatch::class)) {
             $container
                 ->setDefinition(
-                    sprintf('%s.plugin.data_collector', $serviceBusId),
+                    \sprintf('%s.plugin.data_collector', $serviceBusId),
                     new ChildDefinition('prooph_service_bus.plugin.data_collector')
                 )
                 ->addArgument(new Reference($contextFactoryId))
-                ->addArgument(new Reference(sprintf('prooph_service_bus.plugin.symfony_data_collector.%s_bus', $type)))
+                ->addArgument(new Reference(\sprintf('prooph_service_bus.plugin.symfony_data_collector.%s_bus', $type)))
                 ->addTag("prooph_service_bus.{$type}_bus.plugin");
         }
 
         // Logging for each configured service bus
         $container
             ->setDefinition(
-                sprintf('%s.plugin.psr_logger', $serviceBusId),
+                \sprintf('%s.plugin.psr_logger', $serviceBusId),
                 new ChildDefinition('prooph_service_bus.plugin.psr_logger')
             )
             ->setArguments([
                 new Reference($contextFactoryId),
                 new Reference('logger', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
-            ->addTag('monolog.logger', ['channel' => sprintf('%s_bus.%s', $type, $name)])
-            ->addTag(sprintf('prooph_service_bus.%s.plugin', $name));
+            ->addTag('monolog.logger', ['channel' => \sprintf('%s_bus.%s', $type, $name)])
+            ->addTag(\sprintf('prooph_service_bus.%s.plugin', $name));
 
         // define message factory
         $messageFactoryId = 'prooph_service_bus.message_factory.' . $name;
@@ -176,7 +176,7 @@ final class ProophServiceBusExtension extends Extension
         $messageFactoryPluginId = 'prooph_service_bus.message_factory_plugin.' . $name;
         $messageFactoryPluginDefinition = new ChildDefinition('prooph_service_bus.message_factory_plugin');
         $messageFactoryPluginDefinition->setArguments([new Reference($messageFactoryId)]);
-        $messageFactoryPluginDefinition->addTag(sprintf('prooph_service_bus.%s.plugin', $name));
+        $messageFactoryPluginDefinition->addTag(\sprintf('prooph_service_bus.%s.plugin', $name));
 
         $container->setDefinition($messageFactoryPluginId, $messageFactoryPluginDefinition);
 
@@ -198,30 +198,30 @@ final class ProophServiceBusExtension extends Extension
                     new Reference($options['router']['async_switch']),
                 ]);
             }
-            $routerDefinition->addTag(sprintf('prooph_service_bus.%s.plugin', $name));
+            $routerDefinition->addTag(\sprintf('prooph_service_bus.%s.plugin', $name));
 
             $container->setDefinition($routerId, $routerDefinition);
         }
 
         // define service locator
-        $routeTargets = array_values($options['router']['routes'] ?? []);
+        $routeTargets = \array_values($options['router']['routes'] ?? []);
         if ($type === 'event') {
-            $routeTargets = array_merge([], ...$routeTargets);
+            $routeTargets = \array_merge([], ...$routeTargets);
         }
-        $routeTargets = array_unique($routeTargets);
-        $serviceLocatorId = sprintf('%s.plugin.service_locator.locator', $name);
+        $routeTargets = \array_unique($routeTargets);
+        $serviceLocatorId = \sprintf('%s.plugin.service_locator.locator', $name);
         $serviceLocator = $container->register($serviceLocatorId, ServiceLocator::class);
         $serviceLocator->addTag('container.service_locator');
-        $serviceLocator->setArgument(0, array_map(function (string $id) {
+        $serviceLocator->setArgument(0, \array_map(function (string $id) {
             return new Reference($id);
-        }, array_combine($routeTargets, $routeTargets)));
+        }, \array_combine($routeTargets, $routeTargets)));
 
         // and the plugin for it
         $serviceLocatorPlugin = new ChildDefinition('prooph_service_bus.plugin.service_locator');
         $serviceLocatorPlugin->setArgument(0, new Reference($serviceLocatorId));
-        $serviceLocatorPlugin->addTag(sprintf('prooph_service_bus.%s.plugin', $name));
-        $container->setDefinition(sprintf('%s.plugin.service_locator', $name), $serviceLocatorPlugin);
+        $serviceLocatorPlugin->addTag(\sprintf('prooph_service_bus.%s.plugin', $name));
+        $container->setDefinition(\sprintf('%s.plugin.service_locator', $name), $serviceLocatorPlugin);
 
-        $container->setParameter(sprintf('prooph_service_bus.%s.configuration', $name), $options);
+        $container->setParameter(\sprintf('prooph_service_bus.%s.configuration', $name), $options);
     }
 }

--- a/src/Exception/CompilerPassException.php
+++ b/src/Exception/CompilerPassException.php
@@ -8,7 +8,7 @@ class CompilerPassException extends RuntimeException
 {
     public static function messageTagMissing(string $serviceId): self
     {
-        return new self(sprintf(
+        return new self(\sprintf(
             'The "message" tag key is missing from tag. '
                 . 'Either provide a "message" tag or enable "message_detection" for service "%s"',
             $serviceId
@@ -17,7 +17,7 @@ class CompilerPassException extends RuntimeException
 
     public static function tagCountExceeded(string $type, string $serviceId, string $busName): self
     {
-        return new self(sprintf(
+        return new self(\sprintf(
             'More than 1 %s handler tagged on service "%s" with tag "%s". Only events can have multiple handlers',
             $type,
             $serviceId,
@@ -27,7 +27,7 @@ class CompilerPassException extends RuntimeException
 
     public static function unknownHandlerClass(string $className, string $serviceId, string $busName): self
     {
-        return new self(sprintf(
+        return new self(\sprintf(
             'Service %s has been tagged as %s handler, but its class %s does not exist',
             $serviceId,
             $busName,

--- a/src/MessageContext/ContextFactory.php
+++ b/src/MessageContext/ContextFactory.php
@@ -30,7 +30,7 @@ class ContextFactory
             'message-data' => $this->messageConverter->convertMessageToArray($message),
             'message-name' => $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_NAME),
             'message-handled' => $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED),
-            'message-handler' => is_object($handler) ? get_class($handler) : (string) $handler,
+            'message-handler' => \is_object($handler) ? \get_class($handler) : (string) $handler,
         ];
 
         if ($messageBus instanceof NamedMessageBus) {

--- a/src/MessageContext/DefaultMessageDataConverter.php
+++ b/src/MessageContext/DefaultMessageDataConverter.php
@@ -29,7 +29,7 @@ final class DefaultMessageDataConverter implements MessageDataConverter
             }
         }
 
-        if (is_array($message)) {
+        if (\is_array($message)) {
             return $message;
         }
 

--- a/src/Plugin/DataCollector.php
+++ b/src/Plugin/DataCollector.php
@@ -31,7 +31,7 @@ class DataCollector extends BaseDataCollector
     {
         foreach ($this->busNames as $busName) {
             $this->data['config'][$busName] = $this->container->getParameter(
-                sprintf('prooph_service_bus.%s.configuration', $busName)
+                \sprintf('prooph_service_bus.%s.configuration', $busName)
             );
         }
     }
@@ -46,12 +46,12 @@ class DataCollector extends BaseDataCollector
 
     public function totalMessageCount(): int
     {
-        return array_sum(array_map('count', $this->data['messages']));
+        return \array_sum(\array_map('count', $this->data['messages']));
     }
 
     public function totalBusCount(): int
     {
-        return count($this->data['messages']);
+        return \count($this->data['messages']);
     }
 
     public function messages(): array
@@ -76,7 +76,7 @@ class DataCollector extends BaseDataCollector
 
     public function totalBusDuration(): int
     {
-        return array_sum($this->data['duration']);
+        return \array_sum($this->data['duration']);
     }
 
     public function busType(): string
@@ -86,7 +86,7 @@ class DataCollector extends BaseDataCollector
 
     public function getName(): string
     {
-        return sprintf('prooph.%s_bus', $this->data['bus_type']);
+        return \sprintf('prooph.%s_bus', $this->data['bus_type']);
     }
 
     public function addMessageBus(string $busName): void

--- a/src/Plugin/DataCollectorPlugin.php
+++ b/src/Plugin/DataCollectorPlugin.php
@@ -45,9 +45,9 @@ class DataCollectorPlugin extends AbstractPlugin
         }
 
         if (! $messageBus instanceof NamedMessageBus) {
-            throw new RuntimeException(sprintf(
+            throw new RuntimeException(\sprintf(
                 'To use the Symfony DataCollector, the Bus "%s" needs to implement "%s"',
-                get_class($messageBus),
+                \get_class($messageBus),
                 NamedMessageBus::class
             ));
         }
@@ -100,7 +100,7 @@ class DataCollectorPlugin extends AbstractPlugin
             $log = [
                 'id' => (string) $message->uuid(),
                 'message' => $messageName,
-                'handler' => is_object($handler) ? get_class($handler) : (string) $handler,
+                'handler' => \is_object($handler) ? \get_class($handler) : (string) $handler,
             ];
             foreach ($actionEvent->getParam('event-listeners', []) as $handler) {
                 $this->data->addCallstack($messageBus->busName(), $log);

--- a/src/Plugin/StopwatchPlugin.php
+++ b/src/Plugin/StopwatchPlugin.php
@@ -35,7 +35,7 @@ class StopwatchPlugin extends AbstractPlugin
             $message = $event->getParam(MessageBus::EVENT_PARAM_MESSAGE);
             $messageBus = $event->getTarget();
             if ($messageBus instanceof NamedMessageBus) {
-                return sprintf(
+                return \sprintf(
                     '%s:%s:%s',
                     $message->messageType(),
                     $messageBus->busName(),
@@ -43,7 +43,7 @@ class StopwatchPlugin extends AbstractPlugin
                 );
             }
 
-            return sprintf(
+            return \sprintf(
                 '%s:%s',
                 $message->messageType(),
                 $event->getParam(MessageBus::EVENT_PARAM_MESSAGE_NAME)

--- a/test/DependencyInjection/AbstractServiceBusExtensionTestCase.php
+++ b/test/DependencyInjection/AbstractServiceBusExtensionTestCase.php
@@ -517,7 +517,7 @@ abstract class AbstractServiceBusExtensionTestCase extends TestCase
         } else {
             $dumper = new YamlDumper($container);
         }
-        self::assertInstanceOf(Dumper::class, $dumper, sprintf('Test type "%s" not supported', get_class($this)));
+        self::assertInstanceOf(Dumper::class, $dumper, \sprintf('Test type "%s" not supported', \get_class($this)));
         self::assertNotEmpty($dumper->dump());
 
         self::assertNotEmpty((new PhpDumper($container))->dump(), 'PHP cache cannot be warmuped correctly.');
@@ -525,7 +525,7 @@ abstract class AbstractServiceBusExtensionTestCase extends TestCase
 
     private static function assertHasPlugin(string $className, CommandBus $bus)
     {
-        $plugins = array_filter(array_column($bus->plugins(), 'plugin'), function (Plugin $plugin) use ($className) {
+        $plugins = \array_filter(\array_column($bus->plugins(), 'plugin'), function (Plugin $plugin) use ($className) {
             return $plugin instanceof $className;
         });
         self::assertCount(1, $plugins, "No plugin of class $className has been attached");
@@ -533,7 +533,7 @@ abstract class AbstractServiceBusExtensionTestCase extends TestCase
 
     private static function assertNotHasPlugin(string $className, CommandBus $bus)
     {
-        $plugins = array_filter(array_column($bus->plugins(), 'plugin'), function (Plugin $plugin) use ($className) {
+        $plugins = \array_filter(\array_column($bus->plugins(), 'plugin'), function (Plugin $plugin) use ($className) {
             return $plugin instanceof $className;
         });
         self::assertCount(0, $plugins, "A plugin of class $className has been attached");

--- a/test/DependencyInjection/ContainerBuilder.php
+++ b/test/DependencyInjection/ContainerBuilder.php
@@ -52,7 +52,7 @@ class ContainerBuilder
         $this->parameters = [
             'kernel.debug' => false,
             'kernel.bundles' => [],
-            'kernel.cache_dir' => sys_get_temp_dir(),
+            'kernel.cache_dir' => \sys_get_temp_dir(),
             'kernel.environment' => 'test',
             'kernel.root_dir' => __DIR__ . '/../../src',
         ];
@@ -60,28 +60,28 @@ class ContainerBuilder
 
     public function withParameters(array $parameters): self
     {
-        $this->parameters = array_merge($this->parameters, $parameters);
+        $this->parameters = \array_merge($this->parameters, $parameters);
 
         return $this;
     }
 
     public function withExtensions(ExtensionInterface ...$extensions): self
     {
-        $this->extensions = array_merge($this->extensions, $extensions);
+        $this->extensions = \array_merge($this->extensions, $extensions);
 
         return $this;
     }
 
     public function withCompilerPasses(CompilerPassInterface ...$compilerPasses): self
     {
-        $this->compilerPasses = array_merge($this->compilerPasses, $compilerPasses);
+        $this->compilerPasses = \array_merge($this->compilerPasses, $compilerPasses);
 
         return $this;
     }
 
     public function withConfigFiles(string ...$fileNames): self
     {
-        $this->configFiles = array_merge($this->configFiles, $fileNames);
+        $this->configFiles = \array_merge($this->configFiles, $fileNames);
 
         return $this;
     }
@@ -89,17 +89,17 @@ class ContainerBuilder
     public function compile(): SymfonyContainerBuilder
     {
         $container = new SymfonyContainerBuilder(new ParameterBag($this->parameters));
-        array_walk($this->extensions, [$container, 'registerExtension']);
+        \array_walk($this->extensions, [$container, 'registerExtension']);
 
-        $fileLoader = call_user_func($this->fileLoaderFactory, $container);
-        array_walk($this->configFiles, function (string $fileName) use ($fileLoader) {
+        $fileLoader = \call_user_func($this->fileLoaderFactory, $container);
+        \array_walk($this->configFiles, function (string $fileName) use ($fileLoader) {
             $fileLoader->load("$fileName.{$this->fileExtension}");
         });
 
         // array_walk is impossible here because the key will be passed as second parameter
-        array_map([$container, 'addCompilerPass'], $this->compilerPasses);
+        \array_map([$container, 'addCompilerPass'], $this->compilerPasses);
 
-        if (class_exists(ResolveChildDefinitionsPass::class)) {
+        if (\class_exists(ResolveChildDefinitionsPass::class)) {
             $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveChildDefinitionsPass()]);
         } else {
             $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveDefinitionTemplatesPass()]);

--- a/test/DependencyInjection/Fixture/config/xml/command_bus_multiple.xml
+++ b/test/DependencyInjection/Fixture/config/xml/command_bus_multiple.xml
@@ -6,6 +6,11 @@
                xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
 
+    <srv:services>
+        <srv:service id="Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler"></srv:service>
+        <srv:service id="Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler"></srv:service>
+    </srv:services>
+
     <config>
         <command_bus name="main_command_bus" message_factory="prooph_service_bus.message_factory">
             <plugin>prooph_service_bus.handle_command_invoke_strategy</plugin>

--- a/test/DependencyInjection/Fixture/config/xml/event_bus_multiple.xml
+++ b/test/DependencyInjection/Fixture/config/xml/event_bus_multiple.xml
@@ -5,6 +5,12 @@
                xmlns:srv="http://symfony.com/schema/dic/services"
                xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
+
+    <srv:services>
+        <srv:service id="Prooph\ProophessorDo\Projection\Todo\TodoProjector"></srv:service>
+        <srv:service id="Prooph\ProophessorDo\Projection\User\UserProjector"></srv:service>
+    </srv:services>
+
     <config>
         <event_bus name="main_event_bus" message_factory="prooph_service_bus.message_factory">
             <plugin>prooph_service_bus.on_event_invoke_strategy</plugin>
@@ -19,7 +25,7 @@
             <router>
                 <route event="Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted">
                     <listener>Prooph\ProophessorDo\Projection\Todo\TodoProjector</listener>
-                    <listener>Prooph\ProophessorDo\Projection\Todo\UserProjector</listener>
+                    <listener>Prooph\ProophessorDo\Projection\User\UserProjector</listener>
                 </route>
             </router>
         </event_bus>

--- a/test/DependencyInjection/Fixture/config/xml/query_bus_multiple.xml
+++ b/test/DependencyInjection/Fixture/config/xml/query_bus_multiple.xml
@@ -6,6 +6,11 @@
                xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://getprooph.org/schemas/symfony-dic/prooph http://getprooph.org/schemas/symfony-dic/prooph/service_bus-5.1.xsd">
 
+    <srv:services>
+        <srv:service id="Prooph\ProophessorDo\Model\User\Query\UserListUserHandler"></srv:service>
+        <srv:service id="Prooph\ProophessorDo\Model\User\Query\TodoListHandler"></srv:service>
+    </srv:services>
+
     <config>
         <query_bus name="main_query_bus" message_factory="prooph_service_bus.message_factory">
             <plugin>prooph_service_bus.finder_invoke_strategy</plugin>

--- a/test/DependencyInjection/Fixture/config/yml/command_bus_multiple.yml
+++ b/test/DependencyInjection/Fixture/config/yml/command_bus_multiple.yml
@@ -1,3 +1,7 @@
+services:
+    'Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler': ~
+    'Prooph\ProophessorDo\Model\User\Handler\UpdateUserHandler': ~
+
 prooph_service_bus:
   command_buses:
     main_command_bus:

--- a/test/DependencyInjection/Fixture/config/yml/event_bus_multiple.yml
+++ b/test/DependencyInjection/Fixture/config/yml/event_bus_multiple.yml
@@ -1,3 +1,7 @@
+services:
+    'Prooph\ProophessorDo\Projection\Todo\TodoProjector': ~
+    'Prooph\ProophessorDo\Projection\User\UserProjector': ~
+
 prooph_service_bus:
   event_buses:
     main_event_bus:

--- a/test/DependencyInjection/Fixture/config/yml/query_bus_multiple.yml
+++ b/test/DependencyInjection/Fixture/config/yml/query_bus_multiple.yml
@@ -1,3 +1,7 @@
+services:
+    Prooph\ProophessorDo\Model\User\Query\UserListUserHandler: ~
+    Prooph\ProophessorDo\Model\User\Query\TodoListHandler: ~
+
 prooph_service_bus:
   query_buses:
     main_query_bus:


### PR DESCRIPTION
Due to a [Symfony bug](https://github.com/symfony/symfony/issues/33942), the testsuite is broken on the latest Symfony release (4.3.5).

The current test suite also misses a bunch of service definitions and this is a problem since Symfony 4.2.0 (I am still not sure why, seems like the services were auto registered before that?).

This PR fixes all of that + some CS violations.

The testsuite will magically pass once Symfony 4.3.6 is released.

We can wait to merge 'till then, if you prefer :)

However, it's possible to test it locally by running `composer require symfony/dependency-injection:4.3.x-dev@dev` prior to running `phpunit`.